### PR TITLE
add release deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,9 @@ tests =
   pytest-salt-factories>=0.121.1
 dev =
   nox
+release =
+  twine
+  wheel
 docs =
   sphinx
   sphinx-material-saltstack


### PR DESCRIPTION
What it says on the tin - allows `python -m pip install -e .[release]` to
install the release dependencies.
