### PR TITLE
Adding python3-enchant for sphinx reqs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ build-docs-html:
   stage: build-docs
   image: python:3.8
   script:
+    - apt update && apt install python3-enchant
     - pip install -U pip setuptools wheel nox
     - nox -e docs
     - mv docs/_build/html html


### PR DESCRIPTION
Adding `python3-enchant` package to `python:3.8` container image, to resolve CI/CD issue:

```
Running Sphinx v4.2.0
Extension error:
Could not import extension sphinxcontrib.spelling (exception: The 'enchant' C library was not found and maybe needs to be installed.
See  https://pyenchant.github.io/pyenchant/install.html
```