### PR TITLE
Added get function for vmc distributed firewall rules and corresponding unit tests

### DIFF
--- a/docs/ref/modules/all.rst
+++ b/docs/ref/modules/all.rst
@@ -30,6 +30,7 @@ Execution Modules
     saltext.vmware.modules.vm
     saltext.vmware.modules.vmc_dhcp_profiles
     saltext.vmware.modules.vmc_direct_connect
+    saltext.vmware.modules.vmc_distributed_firewall_rules
     saltext.vmware.modules.vmc_dns_forwarder
     saltext.vmware.modules.vmc_nat_rules
     saltext.vmware.modules.vmc_networks

--- a/docs/ref/modules/saltext.vmware.modules.vmc_distributed_firewall_rules.rst
+++ b/docs/ref/modules/saltext.vmware.modules.vmc_distributed_firewall_rules.rst
@@ -1,0 +1,6 @@
+
+saltext.vmware.modules.vmc_distributed_firewall_rules
+=====================================================
+
+.. automodule:: saltext.vmware.modules.vmc_distributed_firewall_rules
+    :members:

--- a/src/saltext/vmware/modules/vmc_distributed_firewall_rules.py
+++ b/src/saltext/vmware/modules/vmc_distributed_firewall_rules.py
@@ -1,0 +1,118 @@
+"""
+Salt execution module for VMC distributed firewall rules
+Provides methods to Create, Read, Update and Delete Distributed firewall rules.
+"""
+import logging
+import os
+
+from saltext.vmware.utils import vmc_constants
+from saltext.vmware.utils import vmc_request
+from saltext.vmware.utils import vmc_templates
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "vmc_distributed_firewall_rules"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def get(
+    hostname,
+    refresh_key,
+    authorization_host,
+    org_id,
+    sddc_id,
+    domain_id,
+    security_policy_id,
+    verify_ssl=True,
+    cert=None,
+    cursor=None,
+    page_size=None,
+    sort_by=None,
+    sort_ascending=None,
+):
+    """
+    Retrieves distributed firewall rules for Given SDDC
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt vm_minion vmc_distributed_firewall_rules.get hostname=nsxt-manager.local domain_id=cgw ...
+
+    hostname
+        The host name of NSX-T manager
+
+    refresh_key
+        API Token of the user which is used to get the Access Token required for VMC operations
+
+    authorization_host
+        Hostname of the VMC cloud console
+
+    org_id
+        The Id of organization to which the SDDC belongs to
+
+    sddc_id
+        The Id of SDDC for which the distributed firewall rules should be retrieved
+
+    domain_id
+        The domain_id for which the distributed firewall rules should be retrieved
+
+    security_policy_id
+        Security policy id for which rule should be retrieved
+
+    verify_ssl
+        (Optional) Option to enable/disable SSL verification. Enabled by default.
+        If set to False, the certificate validation is skipped.
+
+    cert
+        (Optional) Path to the SSL certificate file to connect to NSX-T manager.
+        The certificate can be retrieved from browser.
+
+    cursor
+        (Optional) Opaque cursor to be used for getting next page of records (supplied by current result page)
+
+    page_size
+        (Optional) Maximum number of results to return in this page. Default page size is 1000.
+
+    sort_by
+        (Optional) Field by which records are sorted
+
+    sort_ascending
+        (Optional) Boolean value to sort result in ascending order. Enabled by default.
+
+    """
+    log.info("Retrieving %s distributed firewall rules for SDDC %s", domain_id, sddc_id)
+
+    api_url_base = vmc_request.set_base_url(hostname)
+    api_url = (
+        "{base_url}vmc/reverse-proxy/api/orgs/{org_id}/sddcs/{sddc_id}/"
+        "policy/api/v1/infra/domains/{domain_id}/security-policies/{security_policy_id}/rules"
+    )
+    api_url = api_url.format(
+        base_url=api_url_base,
+        org_id=org_id,
+        sddc_id=sddc_id,
+        domain_id=domain_id,
+        security_policy_id=security_policy_id,
+    )
+
+    params = vmc_request._filter_kwargs(
+        allowed_kwargs=["cursor", "page_size", "sort_ascending", "sort_by"],
+        cursor=cursor,
+        page_size=page_size,
+        sort_by=sort_by,
+        sort_ascending=sort_ascending,
+    )
+    return vmc_request.call_api(
+        method=vmc_constants.GET_REQUEST_METHOD,
+        url=api_url,
+        refresh_key=refresh_key,
+        authorization_host=authorization_host,
+        description="vmc_distributed_firewall_rules.get",
+        verify_ssl=verify_ssl,
+        cert=cert,
+        params=params,
+    )

--- a/tests/unit/modules/test_vmc_distributed_firewall_rules.py
+++ b/tests/unit/modules/test_vmc_distributed_firewall_rules.py
@@ -1,0 +1,136 @@
+"""
+    Unit tests for vmc_distributed_firewall_rules execution module
+"""
+from unittest.mock import patch
+
+import pytest
+import saltext.vmware.modules.vmc_distributed_firewall_rules as vmc_distributed_firewall_rules
+from saltext.vmware.utils import vmc_constants
+
+
+@pytest.fixture
+def distributed_firewall_rules_data_by_id(mock_vmc_request_call_api):
+    data = {
+        "action": "DROP",
+        "resource_type": "Rule",
+        "id": "rule-id",
+        "display_name": "DFR_001",
+        "description": " comm entry",
+        "path": "/infra/domains/cgw/security-policies/SP_1/rules/DFR_001",
+        "relative_path": "DFR_001",
+        "parent_path": "/infra/domains/cgw/security-policies/SP_1",
+        "unique_id": "1026",
+        "marked_for_delete": False,
+        "overridden": False,
+        "rule_id": 1026,
+        "sequence_number": 1,
+        "sources_excluded": False,
+        "destinations_excluded": False,
+        "source_groups": ["/infra/domains/cgw/groups/SG_CGW_001"],
+        "destination_groups": ["ANY"],
+        "services": ["ANY"],
+        "profiles": ["ANY"],
+        "logged": False,
+        "scope": ["ANY"],
+        "disabled": False,
+        "direction": "IN_OUT",
+        "ip_protocol": "IPV4_IPV6",
+        "is_default": False,
+        "_create_time": 1619101829635,
+        "_create_user": "pnaval@vmware.com",
+        "_last_modified_time": 1619101829641,
+        "_last_modified_user": "pnaval@vmware.com",
+        "_system_owned": False,
+        "_protection": "NOT_PROTECTED",
+        "_revision": 0,
+    }
+    mock_vmc_request_call_api.return_value = data
+    yield data
+
+
+@pytest.fixture
+def distributed_firewall_rules_data(
+    mock_vmc_request_call_api, distributed_firewall_rules_data_by_id
+):
+    data = {"result_count": 1, "results": [distributed_firewall_rules_data_by_id]}
+    mock_vmc_request_call_api.return_value = data
+    yield data
+
+
+def test_get_distributed_firewall_rules_should_return_api_response(distributed_firewall_rules_data):
+    assert (
+        vmc_distributed_firewall_rules.get(
+            hostname="hostname",
+            refresh_key="refresh_key",
+            authorization_host="authorization_host",
+            org_id="org_id",
+            sddc_id="sddc_id",
+            domain_id="domain_id",
+            security_policy_id="security_policy_id",
+            verify_ssl=False,
+        )
+        == distributed_firewall_rules_data
+    )
+
+
+def test_get_distributed_firewall_rules_called_with_url():
+    expected_url = (
+        "https://hostname/vmc/reverse-proxy/api/orgs/org_id/sddcs/sddc_id/policy/api/"
+        "v1/infra/domains/domain_id/security-policies/security_policy_id/rules"
+    )
+    with patch("saltext.vmware.utils.vmc_request.call_api", autospec=True) as vmc_call_api:
+        result = vmc_distributed_firewall_rules.get(
+            hostname="hostname",
+            refresh_key="refresh_key",
+            authorization_host="authorization_host",
+            org_id="org_id",
+            sddc_id="sddc_id",
+            domain_id="domain_id",
+            security_policy_id="security_policy_id",
+            verify_ssl=False,
+        )
+
+    call_kwargs = vmc_call_api.mock_calls[0][-1]
+    assert call_kwargs["url"] == expected_url
+    assert call_kwargs["method"] == vmc_constants.GET_REQUEST_METHOD
+
+
+@pytest.mark.parametrize(
+    "actual_args, expected_params",
+    [
+        # all actual args are None
+        (
+            {},
+            {},
+        ),
+        # all actual args have few param values
+        (
+            {"page_size": 2},
+            {"page_size": 2},
+        ),
+        # all actual args have all possible params
+        (
+            {"cursor": "00012", "page_size": 2, "sort_by": ["action"], "sort_ascending": True},
+            {"cursor": "00012", "page_size": 2, "sort_by": ["action"], "sort_ascending": True},
+        ),
+    ],
+)
+def test_assert_get_distributed_firewall_rules_should_correctly_filter_args(
+    actual_args, expected_params
+):
+    common_actual_args = {
+        "hostname": "hostname",
+        "refresh_key": "refresh_key",
+        "authorization_host": "authorization_host",
+        "org_id": "org_id",
+        "sddc_id": "sddc_id",
+        "domain_id": "domain_id",
+        "security_policy_id": "security_policy_id",
+        "verify_ssl": False,
+    }
+    with patch("saltext.vmware.utils.vmc_request.call_api", autospec=True) as vmc_call_api:
+        actual_args.update(common_actual_args)
+        vmc_distributed_firewall_rules.get(**actual_args)
+
+    call_kwargs = vmc_call_api.mock_calls[0][-1]
+    assert call_kwargs["params"] == expected_params


### PR DESCRIPTION
Added params tests in https://github.com/saltstack/salt-ext-modules-vmware/pull/81