### PR TITLE
Add, remove and list License keys

### DIFF
--- a/docs/architecture/20210901-build-test-deployment-pipeline.rst
+++ b/docs/architecture/20210901-build-test-deployment-pipeline.rst
@@ -241,7 +241,7 @@ same process as any other build. Our confidence should be high that our test
 suite and full pipeline will succeed, with such trivial non-code changes.
 
 The only difference between the regular "nightly build" process, and a PyPI
-releas, will be that if there is a tag corresponding to the commit that created
+release, will be that if there is a tag corresponding to the commit that created
 this build, in addition to uploading the artifacts to our archive, the
 artifacts will also be released to PyPI and whatever location is hosting our
 docs.

--- a/docs/ref/modules/all.rst
+++ b/docs/ref/modules/all.rst
@@ -16,6 +16,7 @@ Execution Modules
     saltext.vmware.modules.dvswitch
     saltext.vmware.modules.esxi
     saltext.vmware.modules.folder
+    saltext.vmware.modules.license_mgr
     saltext.vmware.modules.nsxt_compute_manager
     saltext.vmware.modules.nsxt_ip_blocks
     saltext.vmware.modules.nsxt_ip_pools

--- a/docs/ref/modules/saltext.vmware.modules.license_mgr.rst
+++ b/docs/ref/modules/saltext.vmware.modules.license_mgr.rst
@@ -1,0 +1,6 @@
+
+saltext.vmware.modules.license_mgr
+==================================
+
+.. automodule:: saltext.vmware.modules.license_mgr
+    :members:

--- a/docs/ref/states/all.rst
+++ b/docs/ref/states/all.rst
@@ -12,6 +12,7 @@ State Modules
     saltext.vmware.states.datastore
     saltext.vmware.states.esxi
     saltext.vmware.states.folder
+    saltext.vmware.states.license_mgr
     saltext.vmware.states.nsxt_compute_manager
     saltext.vmware.states.nsxt_ip_blocks
     saltext.vmware.states.nsxt_ip_pools

--- a/docs/ref/states/saltext.vmware.states.license_mgr.rst
+++ b/docs/ref/states/saltext.vmware.states.license_mgr.rst
@@ -1,0 +1,6 @@
+
+saltext.vmware.states.license_mgr
+=================================
+
+.. automodule:: saltext.vmware.states.license_mgr
+    :members:

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -56,7 +56,6 @@ def add(license_key, **kwargs):
         salt '*' vmware_license_mgr.add license_key datacenter_name=dc1
     """
     log.debug("start vmware ext license_mgr add license_key")
-
     ret = {}
     op = {}
     for key, value in kwargs.items():
@@ -91,7 +90,9 @@ def add(license_key, **kwargs):
         salt.exceptions.VMwareApiError,
         salt.exceptions.VMwareObjectRetrievalError,
         salt.exceptions.VMwareRuntimeError,
+        salt.exceptions.CommandExecutionError,
     ) as exc:
+        log.exception(exc)
         ret[
             "message"
         ] = f"Failed to add a license key '{license_key}' due to Exception '{str(exc)}'"
@@ -157,7 +158,6 @@ def remove(license_key, **kwargs):
         salt '*' vmware_license_mgr.remove license_key
     """
     log.debug("start vmware ext license_mgr remove license_key")
-
     ret = {}
     op = {}
     for key, value in kwargs.items():
@@ -187,9 +187,11 @@ def remove(license_key, **kwargs):
         )
     except (
         salt.exceptions.VMwareApiError,
-        salt.exceptions.VMwareObjectRetrievalErrori,
+        salt.exceptions.VMwareObjectRetrievalError,
         salt.exceptions.VMwareRuntimeError,
+        salt.exceptions.CommandExecutionError,
     ) as exc:
+        log.exception(exc)
         ret[
             "message"
         ] = f"Failed to remove license key '{license_key}' due to Exception '{str(exc)}'"

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -1,0 +1,120 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+import pudb
+import salt.exceptions
+import saltext.vmware.utils.common as utils_common
+import saltext.vmware.utils.license_mgr as utils_license_mgr
+from saltext.vmware.utils.connect import get_service_instance
+
+log = logging.getLogger(__name__)
+
+try:
+    from pyVmomi import vim
+
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+
+__virtualname__ = "vmware_license_mgr"
+__proxyenabled__ = ["vmware_license_mgr"]
+__func_alias__ = {"list_": "list", "get_": "get"}
+
+
+def __virtual__():
+    if not HAS_PYVMOMI:
+        return False, "Unable to import pyVmomi module."
+    return __virtualname__
+
+
+def list_(service_instance=None):
+    """
+    Returns a list of license managers for the specified host.
+
+    .. code-block:: bash
+
+        salt '*' vmware_license_mgr.list
+    """
+    pu.db
+
+    log.debug("DGM vmware ext license_mgr list entered")
+    if service_instance is None:
+        service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
+    log.debug("DGM vmware ext license_mgr list retrieved service_instance")
+    return utils_license_mgr.list_license_mgrs(service_instance)
+
+
+## def create(name, service_instance=None):
+##     """
+##     Creates a datacenter.
+##
+##     Supported proxies: esxdatacenter
+##
+##     name
+##         The datacenter name
+##
+##     .. code-block:: bash
+##
+##         salt '*' vmware_datacenter.create dc1
+##     """
+##     if service_instance is None:
+##         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
+##     try:
+##         utils_datacenter.create_datacenter(service_instance, name)
+##     except salt.exceptions.VMwareApiError as exc:
+##         return {name: False, "reason": str(exc)}
+##     return {name: True}
+
+
+def get_(name, service_instance=None):
+    """
+    Get the properties of a License Manager
+
+    name
+        The vcenter name
+
+    .. code-block:: bash
+
+        salt '*' vmware_license_mgr.get dc1
+    """
+    log.debug(f"DGM vmware ext license_mgr get entered, with name '{name}'")
+    ret = {}
+    if service_instance is None:
+        service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
+    try:
+        licmgr_ref = utils_lic_mgr.get_license_mgr(service_instance, name)
+        licmgr = utils_common.get_mors_with_properties(
+            service_instance,
+            vim.LicenseAssignmentManager,
+            container_ref=vc_ref,
+            local_properties=True,
+        )
+        if licmgr:
+            ret = licmgr[0]
+    except (salt.exceptions.VMwareApiError, salt.exceptions.VMwareObjectRetrievalError) as exc:
+        return {name: False, "reason": str(exc)}
+    return ret
+
+
+## def delete(name, service_instance=None):
+##     """
+##     Deletes a datacenter.
+##
+##     Supported proxies: esxdatacenter
+##
+##     name
+##         The datacenter name
+##
+##     .. code-block:: bash
+##
+##         salt '*' vmware_datacenter.delete dc1
+##     """
+##     if service_instance is None:
+##         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
+##     try:
+##         utils_datacenter.delete_datacenter(service_instance, name)
+##     except (salt.exceptions.VMwareApiError, salt.exceptions.VMwareObjectRetrievalError) as exc:
+##         return {name: False, "reason": str(exc)}
+##     return {name: True}

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -89,14 +89,12 @@ def add(license_key, **kwargs):
         salt.exceptions.CommandExecutionError,
     ) as exc:
         log.exception(exc)
-        ret["message"] = f"Failed to add a license key '{license_key}' due to Exception '{exc}'"
+        ret["message"] = f"Failed to add a license key due to Exception '{exc}'"
         ret["result"] = False
         return ret
 
     if not result:
-        ret[
-            "message"
-        ] = f"Failed specified license key '{license_key}' was not added to License Manager"
+        ret["message"] = f"Failed specified license key was not added to License Manager"
         ret["result"] = False
 
     return ret
@@ -115,11 +113,6 @@ def list_(service_instance=None):
     """
     if service_instance is None:
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
-
-    if __opts__.get("test", None):
-        ret["licenses"] = "DGMTT-FAKED-TESTS-LICEN-SE012"
-        ret["message"] = "Test dry-run, not really connected to a vCenter testing"
-        return ret
 
     return utils_license_mgr.list_licenses(service_instance)
 
@@ -181,14 +174,12 @@ def remove(license_key, **kwargs):
         salt.exceptions.CommandExecutionError,
     ) as exc:
         log.exception(exc)
-        ret["message"] = f"Failed to remove license key '{license_key}' due to Exception '{exc}'"
+        ret["message"] = f"Failed to remove license key due to Exception '{exc}'"
         ret["result"] = False
         return ret
 
     if not result:
-        ret[
-            "message"
-        ] = f"Failed specified license key '{license_key}' was not found in License Manager"
+        ret["message"] = f"Failed specified license key was not found in License Manager"
         ret["result"] = False
 
     return ret

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -2,13 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 
+import pudb
 import saltext.vmware.utils.common as utils_common
 import saltext.vmware.utils.license_mgr as utils_license_mgr
 from saltext.vmware.utils.connect import get_service_instance
 
 import salt.exceptions
-
-## import pudb
 
 log = logging.getLogger(__name__)
 
@@ -57,6 +56,8 @@ def add(license, **kwargs):
 
         salt '*' vmware_license_mgr.add license datacenter_name=dc1
     """
+    pu.db
+
     log.debug("start vmware ext license_mgr add license")
 
     ret = {}
@@ -82,8 +83,8 @@ def add(license, **kwargs):
         return ret
 
     try:
-        if "test" in __opts__:
-            ret["licenses"] = license_key
+        if "test" in __opts__ and __opts__["test"]:
+            ret["licenses"] = license
             ret["comment"] = "Test dry-run, not really connected to a vCenter testing"
             return ret
 
@@ -156,7 +157,7 @@ def list_(service_instance=None):
         "vmware ext license_mgr list retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
     )
 
-    if "test" in __opts__:
+    if "test" in __opts__ and __opts__["test"]:
         ret["licenses"] = "DGMTT-FAKED-TESTS-LICEN-SE012"
         ret["comment"] = "Test dry-run, not really connected to a vCenter testing"
         return ret
@@ -215,8 +216,8 @@ def remove(license, **kwargs):
         return ret
 
     try:
-        if "test" in __opts__:
-            ret["licenses"] = license_key
+        if "test" in __opts__ and __opts__["test"]:
+            ret["licenses"] = license
             ret["comment"] = "Test dry-run, not really connected to a vCenter testing"
             return ret
 

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -29,14 +29,24 @@ def __virtual__():
     return __virtualname__
 
 
-def add(license, service_instance=None):
+def add(license, datacenter_name=None, cluster_name=None, esxi_hostname=None):
     """
-    Add a license manager
+    Add a license to specified Cluster, ESXI Server or vCenter
+    If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    Supported proxies: esxi host
+    license
+        License Key to add to license manager
 
-    license:
-        License to remove from license manager
+    datacenter_name
+        Datacenter name to use for the operation [default None]
+
+    cluster_name
+        Name of the cluster to add license [default None]
+
+    esxi_hostname
+        Hostname of the ESXI Server to add license [default None]
+
+    CLI Example:
 
     .. code-block: bash
 
@@ -44,8 +54,7 @@ def add(license, service_instance=None):
     """
     log.debug("DGM vmware ext license_mgr add lic entered")
     ret = {}
-    if service_instance is None:
-        service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
+    service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
     log.debug("DGM vmware ext license_mgr add lic retrieved service_instance")
 
     if not utils_license_mgr.is_vcenter(service_instance):
@@ -54,7 +63,9 @@ def add(license, service_instance=None):
         return ret
 
     try:
-        result = utils_license_mgr.add_license(service_instance, license)
+        result = utils_license_mgr.add_license(
+            service_instance, license, datacenter_name, cluster_name, esxi_hostname
+        )
     except (
         salt.exceptions.VMwareApiError,
         salt.exceptions.VMwareObjectRetrievalError,
@@ -117,14 +128,24 @@ def list_(service_instance=None):
     return utils_license_mgr.list_licenses(service_instance)
 
 
-def remove(license, service_instance=None):
+def remove(license, datacenter_name=None, cluster_name=None, esxi_hostname=None):
     """
-    Remove a license manager
+    Remove a license from specified Cluster, ESXI Server or vCenter
+    If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    Supported proxies: esxi host
+    license
+        License Key to add to license manager
 
-    license:
-        License to remove from license manager
+    datacenter_name
+        Datacenter name to use for the operation [default None]
+
+    cluster_name
+        Name of the cluster to add license [default None]
+
+    esxi_hostname
+        Hostname of the ESXI Server to add license [default None]
+
+    CLI Example:
 
     .. code-block: bash
 
@@ -132,8 +153,7 @@ def remove(license, service_instance=None):
     """
     log.debug("DGM vmware ext license_mgr remove lic entered")
     ret = {}
-    if service_instance is None:
-        service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
+    service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
 
     log.debug("DGM vmware ext license_mgr remove lic retrieved service_instance")
 
@@ -143,7 +163,9 @@ def remove(license, service_instance=None):
         return ret
 
     try:
-        result = utils_license_mgr.remove_license(service_instance, license)
+        result = utils_license_mgr.remove_license(
+            service_instance, license, datacenter_name, cluster_name, esxi_hostname
+        )
     except (
         salt.exceptions.VMwareApiError,
         salt.exceptions.VMwareObjectRetrievalErrori,

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -34,23 +34,20 @@ def add(license, **kwargs):
     Add a license to specified Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    Parameters:
-      Required:
-        * license
-            License Key to add to license manager
+    license
+        License Key to add to license manager
 
-      Optional:
-        * service_instance
-            Use this vCenter service connection instance instead of creating a new one [default None]
+    service_instance
+        Use this vCenter service connection instance instead of creating a new one [default None]
 
-        * datacenter_name
-            Datacenter name to use for the operation [default None]
+    datacenter_name
+        Datacenter name to use for the operation [default None]
 
-        * cluster_name
-            Name of the cluster to add license [default None]
+    cluster_name
+        Name of the cluster to add license [default None]
 
-        * esxi_hostname
-            Hostname of the ESXI Server to add license [default None]
+    esxi_hostname
+        Hostname of the ESXI Server to add license [default None]
 
     CLI Example:
 
@@ -58,7 +55,7 @@ def add(license, **kwargs):
 
         salt '*' vmware_license_mgr.add license datacenter_name=dc1
     """
-    log.debug("DGM vmware ext license_mgr add lic entered")
+    log.debug("start vmware ext license_mgr add license")
     ret = {}
     op = {}
     for key, value in kwargs.items():
@@ -73,7 +70,7 @@ def add(license, **kwargs):
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
 
     log.debug(
-        "DGM vmware ext license_mgr add lic retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
+        "vmware ext license_mgr add lic retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
     )
 
     if not utils_license_mgr.is_vcenter(service_instance):
@@ -141,11 +138,11 @@ def list_(service_instance=None):
 
         salt '*' vmware_license_mgr.list
     """
-    log.debug("DGM vmware ext license_mgr list entered")
+    log.debug("start vmware ext license_mgr list")
     if service_instance is None:
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
     log.debug(
-        "DGM vmware ext license_mgr list retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
+        "vmware ext license_mgr list retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
     )
     return utils_license_mgr.list_licenses(service_instance)
 
@@ -155,23 +152,20 @@ def remove(license, **kwargs):
     Remove a license from specified Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    Parameters:
-      Required:
-        * license
-            License Key to add to license manager
+    license
+        License Key to add to license manager
 
-      Optional:
-        * service_instance
-            Use this vCenter service connection instance instead of creating a new one [default None]
+    service_instance
+        Use this vCenter service connection instance instead of creating a new one [default None]
 
-        * datacenter_name
-            Datacenter name to use for the operation [default None]
+    datacenter_name
+        Datacenter name to use for the operation [default None]
 
-        * cluster_name
-            Name of the cluster to add license [default None]
+    cluster_name
+        Name of the cluster to add license [default None]
 
-        * esxi_hostname
-            Hostname of the ESXI Server to add license [default None]
+    esxi_hostname
+        Hostname of the ESXI Server to add license [default None]
 
     CLI Example:
 
@@ -179,7 +173,7 @@ def remove(license, **kwargs):
 
         salt '*' vmware_license_mgr.remove license
     """
-    log.debug("DGM vmware ext license_mgr remove lic entered")
+    log.debug("start vmware ext license_mgr remove license")
     ## service_instance = None
     ## datacenter_name = None
     ## cluster_name = None
@@ -199,7 +193,7 @@ def remove(license, **kwargs):
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
 
     log.debug(
-        "DGM vmware ext license_mgr remove lic retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
+        "vmware ext license_mgr remove lic retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
     )
 
     if not utils_license_mgr.is_vcenter(service_instance):

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 
+# noreorder
+import salt.exceptions
 import saltext.vmware.utils.common as utils_common
 import saltext.vmware.utils.license_mgr as utils_license_mgr
 from saltext.vmware.utils.connect import get_service_instance
-
-import salt.exceptions
 
 log = logging.getLogger(__name__)
 

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 
-import pudb
-import salt.exceptions
 import saltext.vmware.utils.common as utils_common
 import saltext.vmware.utils.license_mgr as utils_license_mgr
 from saltext.vmware.utils.connect import get_service_instance
+
+import salt.exceptions
+
+## import pudb
 
 log = logging.getLogger(__name__)
 
@@ -56,6 +58,7 @@ def add(license, **kwargs):
         salt '*' vmware_license_mgr.add license datacenter_name=dc1
     """
     log.debug("start vmware ext license_mgr add license")
+
     ret = {}
     op = {}
     for key, value in kwargs.items():
@@ -79,9 +82,17 @@ def add(license, **kwargs):
         return ret
 
     try:
+        if "test" in __opts__:
+            ret["licenses"] = license_key
+            ret["comment"] = "Test dry-run, not really connected to a vCenter testing"
+            return ret
+
         result = utils_license_mgr.add_license(
             service_instance, license, datacenter_name, cluster_name, esxi_hostname
         )
+        if result:
+            ret["licenses"] = license_key
+
     except (
         salt.exceptions.VMwareApiError,
         salt.exceptions.VMwareObjectRetrievalError,
@@ -144,6 +155,12 @@ def list_(service_instance=None):
     log.debug(
         "vmware ext license_mgr list retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
     )
+
+    if "test" in __opts__:
+        ret["licenses"] = "DGMTT-FAKED-TESTS-LICEN-SE012"
+        ret["comment"] = "Test dry-run, not really connected to a vCenter testing"
+        return ret
+
     return utils_license_mgr.list_licenses(service_instance)
 
 
@@ -174,10 +191,6 @@ def remove(license, **kwargs):
         salt '*' vmware_license_mgr.remove license
     """
     log.debug("start vmware ext license_mgr remove license")
-    ## service_instance = None
-    ## datacenter_name = None
-    ## cluster_name = None
-    ## esxi_hostname = None
 
     ret = {}
     op = {}
@@ -202,6 +215,11 @@ def remove(license, **kwargs):
         return ret
 
     try:
+        if "test" in __opts__:
+            ret["licenses"] = license_key
+            ret["comment"] = "Test dry-run, not really connected to a vCenter testing"
+            return ret
+
         result = utils_license_mgr.remove_license(
             service_instance, license, datacenter_name, cluster_name, esxi_hostname
         )

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -55,16 +55,12 @@ def add(license_key, **kwargs):
 
         salt '*' vmware_license_mgr.add license_key datacenter_name=dc1
     """
-    log.debug("start vmware ext license_mgr add license_key")
     ret = {}
-    op = {}
-    for key, value in kwargs.items():
-        op[key] = value
 
-    service_instance = op.pop("service_instance", None)
-    datacenter_name = op.pop("datacenter_name", None)
-    cluster_name = op.pop("cluster_name", None)
-    esxi_hostname = op.pop("esxi_hostname", None)
+    service_instance = kwargs.get("service_instance", None)
+    datacenter_name = kwargs.get("datacenter_name", None)
+    cluster_name = kwargs.get("cluster_name", None)
+    esxi_hostname = kwargs.get("esxi_hostname", None)
 
     if service_instance is None:
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
@@ -75,7 +71,7 @@ def add(license_key, **kwargs):
         return ret
 
     try:
-        if "test" in __opts__ and __opts__["test"]:
+        if __opts__.get("test", None):
             ret["licenses"] = license_key
             ret["message"] = "Test dry-run, not really connected to a vCenter testing"
             return ret
@@ -93,9 +89,7 @@ def add(license_key, **kwargs):
         salt.exceptions.CommandExecutionError,
     ) as exc:
         log.exception(exc)
-        ret[
-            "message"
-        ] = f"Failed to add a license key '{license_key}' due to Exception '{str(exc)}'"
+        ret["message"] = f"Failed to add a license key '{license_key}' due to Exception '{exc}'"
         ret["result"] = False
         return ret
 
@@ -119,11 +113,10 @@ def list_(service_instance=None):
 
         salt '*' vmware_license_mgr.list
     """
-    log.debug("start vmware ext license_mgr list")
     if service_instance is None:
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
 
-    if "test" in __opts__ and __opts__["test"]:
+    if __opts__.get("test", None):
         ret["licenses"] = "DGMTT-FAKED-TESTS-LICEN-SE012"
         ret["message"] = "Test dry-run, not really connected to a vCenter testing"
         return ret
@@ -157,16 +150,12 @@ def remove(license_key, **kwargs):
 
         salt '*' vmware_license_mgr.remove license_key
     """
-    log.debug("start vmware ext license_mgr remove license_key")
     ret = {}
-    op = {}
-    for key, value in kwargs.items():
-        op[key] = value
 
-    service_instance = op.pop("service_instance", None)
-    datacenter_name = op.pop("datacenter_name", None)
-    cluster_name = op.pop("cluster_name", None)
-    esxi_hostname = op.pop("esxi_hostname", None)
+    service_instance = kwargs.get("service_instance", None)
+    datacenter_name = kwargs.get("datacenter_name", None)
+    cluster_name = kwargs.get("cluster_name", None)
+    esxi_hostname = kwargs.get("esxi_hostname", None)
 
     if service_instance is None:
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
@@ -177,7 +166,7 @@ def remove(license_key, **kwargs):
         return ret
 
     try:
-        if "test" in __opts__ and __opts__["test"]:
+        if __opts__.get("test", None):
             ret["licenses"] = license_key
             ret["message"] = "Test dry-run, not really connected to a vCenter testing"
             return ret
@@ -192,9 +181,7 @@ def remove(license_key, **kwargs):
         salt.exceptions.CommandExecutionError,
     ) as exc:
         log.exception(exc)
-        ret[
-            "message"
-        ] = f"Failed to remove license key '{license_key}' due to Exception '{str(exc)}'"
+        ret["message"] = f"Failed to remove license key '{license_key}' due to Exception '{exc}'"
         ret["result"] = False
         return ret
 

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -29,33 +29,52 @@ def __virtual__():
     return __virtualname__
 
 
-def add(license, datacenter_name=None, cluster_name=None, esxi_hostname=None):
+def add(license, **kwargs):
     """
     Add a license to specified Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    license
-        License Key to add to license manager
+    Parameters:
+      Required:
+        * license
+            License Key to add to license manager
 
-    datacenter_name
-        Datacenter name to use for the operation [default None]
+      Optional:
+        * service_instance
+            Use this vCenter service connection instance instead of creating a new one [default None]
 
-    cluster_name
-        Name of the cluster to add license [default None]
+        * datacenter_name
+            Datacenter name to use for the operation [default None]
 
-    esxi_hostname
-        Hostname of the ESXI Server to add license [default None]
+        * cluster_name
+            Name of the cluster to add license [default None]
+
+        * esxi_hostname
+            Hostname of the ESXI Server to add license [default None]
 
     CLI Example:
 
     .. code-block: bash
 
-        salt '*' vmware_license_mgr.add license
+        salt '*' vmware_license_mgr.add license datacenter_name=dc1
     """
     log.debug("DGM vmware ext license_mgr add lic entered")
     ret = {}
-    service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
-    log.debug("DGM vmware ext license_mgr add lic retrieved service_instance")
+    op = {}
+    for key, value in kwargs.items():
+        op[key] = value
+
+    service_instance = op.pop("service_instance", None)
+    datacenter_name = op.pop("datacenter_name", None)
+    cluster_name = op.pop("cluster_name", None)
+    esxi_hostname = op.pop("esxi_hostname", None)
+
+    if service_instance is None:
+        service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
+
+    log.debug(
+        "DGM vmware ext license_mgr add lic retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
+    )
 
     if not utils_license_mgr.is_vcenter(service_instance):
         ret["comment"] = "Failed, not connected to a vCenter"
@@ -71,7 +90,7 @@ def add(license, datacenter_name=None, cluster_name=None, esxi_hostname=None):
         salt.exceptions.VMwareObjectRetrievalError,
         salt.exceptions.VMwareRuntimeError,
     ) as exc:
-        ret["comment"] = f"Failed to remove a license due to Exception '{str(exc)}'"
+        ret["comment"] = f"Failed to add a license due to Exception '{str(exc)}'"
         ret["result"] = False
         return ret
 
@@ -86,8 +105,8 @@ def get_(service_instance=None):
     """
     Get the properties of a License Manager
 
-    name
-        The vcenter name
+    service_instance
+        Use this vCenter service connection instance instead of creating a new one [default None]
 
     .. code-block:: bash
 
@@ -105,7 +124,7 @@ def get_(service_instance=None):
             local_properties=True,
         )
         if licmgr:
-            ret = licmgr[0]
+            ret["stdout"] = licmgr[0]
     except (salt.exceptions.VMwareApiError, salt.exceptions.VMwareObjectRetrievalError) as exc:
         return {name: False, "reason": str(exc)}
     return ret
@@ -115,35 +134,44 @@ def list_(service_instance=None):
     """
     Returns a list of licenses for the specified Service Instance
 
+    service_instance
+        Use this vCenter service connection instance instead of creating a new one [default None]
+
     .. code-block:: bash
 
         salt '*' vmware_license_mgr.list
     """
-    pu.db
-
     log.debug("DGM vmware ext license_mgr list entered")
     if service_instance is None:
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
-    log.debug("DGM vmware ext license_mgr list retrieved service_instance")
+    log.debug(
+        "DGM vmware ext license_mgr list retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
+    )
     return utils_license_mgr.list_licenses(service_instance)
 
 
-def remove(license, datacenter_name=None, cluster_name=None, esxi_hostname=None):
+def remove(license, **kwargs):
     """
     Remove a license from specified Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    license
-        License Key to add to license manager
+    Parameters:
+      Required:
+        * license
+            License Key to add to license manager
 
-    datacenter_name
-        Datacenter name to use for the operation [default None]
+      Optional:
+        * service_instance
+            Use this vCenter service connection instance instead of creating a new one [default None]
 
-    cluster_name
-        Name of the cluster to add license [default None]
+        * datacenter_name
+            Datacenter name to use for the operation [default None]
 
-    esxi_hostname
-        Hostname of the ESXI Server to add license [default None]
+        * cluster_name
+            Name of the cluster to add license [default None]
+
+        * esxi_hostname
+            Hostname of the ESXI Server to add license [default None]
 
     CLI Example:
 
@@ -152,10 +180,27 @@ def remove(license, datacenter_name=None, cluster_name=None, esxi_hostname=None)
         salt '*' vmware_license_mgr.remove license
     """
     log.debug("DGM vmware ext license_mgr remove lic entered")
-    ret = {}
-    service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
+    ## service_instance = None
+    ## datacenter_name = None
+    ## cluster_name = None
+    ## esxi_hostname = None
 
-    log.debug("DGM vmware ext license_mgr remove lic retrieved service_instance")
+    ret = {}
+    op = {}
+    for key, value in kwargs.items():
+        op[key] = value
+
+    service_instance = op.pop("service_instance", None)
+    datacenter_name = op.pop("datacenter_name", None)
+    cluster_name = op.pop("cluster_name", None)
+    esxi_hostname = op.pop("esxi_hostname", None)
+
+    if service_instance is None:
+        service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
+
+    log.debug(
+        "DGM vmware ext license_mgr remove lic retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
+    )
 
     if not utils_license_mgr.is_vcenter(service_instance):
         ret["comment"] = "Failed, not connected to a vCenter"

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -30,13 +30,13 @@ def __virtual__():
     return __virtualname__
 
 
-def add(license, **kwargs):
+def add(license_key, **kwargs):
     """
-    Add a license to specified Cluster, ESXI Server or vCenter
+    Add a license specified by license key to a Datacenter, Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    license
-        License Key to add to license manager
+    license_key
+        License Key which specifies license to add to license manager
 
     service_instance
         Use this vCenter service connection instance instead of creating a new one [default None]
@@ -54,11 +54,11 @@ def add(license, **kwargs):
 
     .. code-block: bash
 
-        salt '*' vmware_license_mgr.add license datacenter_name=dc1
+        salt '*' vmware_license_mgr.add license_key datacenter_name=dc1
     """
     pu.db
 
-    log.debug("start vmware ext license_mgr add license")
+    log.debug("start vmware ext license_mgr add license_key")
 
     ret = {}
     op = {}
@@ -73,9 +73,9 @@ def add(license, **kwargs):
     if service_instance is None:
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
 
-    log.debug(
-        "vmware ext license_mgr add lic retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
-    )
+    ## log.debug(
+    ##     f"vmware ext license_mgr add lic retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
+    ## )
 
     if not utils_license_mgr.is_vcenter(service_instance):
         ret["comment"] = "Failed, not connected to a vCenter"
@@ -84,12 +84,12 @@ def add(license, **kwargs):
 
     try:
         if "test" in __opts__ and __opts__["test"]:
-            ret["licenses"] = license
+            ret["licenses"] = license_key
             ret["comment"] = "Test dry-run, not really connected to a vCenter testing"
             return ret
 
         result = utils_license_mgr.add_license(
-            service_instance, license, datacenter_name, cluster_name, esxi_hostname
+            service_instance, license_key, datacenter_name, cluster_name, esxi_hostname
         )
         if result:
             ret["licenses"] = license_key
@@ -121,19 +121,25 @@ def get_(service_instance=None):
 
         salt '*' vmware_license_mgr.get
     """
+    pu.db
     ret = {}
     if service_instance is None:
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
     try:
-        licmgr_ref = utils_lic_mgr.get_license_mgr(service_instance)
+        licmgr_ref = utils_license_mgr.get_license_mgr(service_instance)
         licmgr = utils_common.get_mors_with_properties(
             service_instance,
             vim.LicenseManager,
-            container_ref=vc_ref,
+            property_list=None,
+            container_ref=licmgr_ref,
+            traversal_spec=None,
             local_properties=True,
         )
         if licmgr:
-            ret["stdout"] = licmgr[0]
+            log.debug(f"license manager mors and properties '{licmgr[0]}'")
+
+            # TBD need a better way to pass back the dictionary
+            ret["mors_properties"] = licmgr[0]
     except (salt.exceptions.VMwareApiError, salt.exceptions.VMwareObjectRetrievalError) as exc:
         return {name: False, "reason": str(exc)}
     return ret
@@ -150,12 +156,14 @@ def list_(service_instance=None):
 
         salt '*' vmware_license_mgr.list
     """
+    pu.db
     log.debug("start vmware ext license_mgr list")
     if service_instance is None:
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
-    log.debug(
-        "vmware ext license_mgr list retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
-    )
+
+    ## log.debug(
+    ##     f"vmware ext license_mgr list retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
+    ## )
 
     if "test" in __opts__ and __opts__["test"]:
         ret["licenses"] = "DGMTT-FAKED-TESTS-LICEN-SE012"
@@ -165,13 +173,13 @@ def list_(service_instance=None):
     return utils_license_mgr.list_licenses(service_instance)
 
 
-def remove(license, **kwargs):
+def remove(license_key, **kwargs):
     """
-    Remove a license from specified Cluster, ESXI Server or vCenter
+    Remove a license specified by license_key from a Datacenter, Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    license
-        License Key to add to license manager
+    license_key
+        License Key which specifies license to remove from the license manager
 
     service_instance
         Use this vCenter service connection instance instead of creating a new one [default None]
@@ -189,9 +197,10 @@ def remove(license, **kwargs):
 
     .. code-block: bash
 
-        salt '*' vmware_license_mgr.remove license
+        salt '*' vmware_license_mgr.remove license_key
     """
-    log.debug("start vmware ext license_mgr remove license")
+    log.debug("start vmware ext license_mgr remove license_key")
+    pu.db
 
     ret = {}
     op = {}
@@ -206,9 +215,9 @@ def remove(license, **kwargs):
     if service_instance is None:
         service_instance = get_service_instance(opts=__opts__, pillar=__pillar__)
 
-    log.debug(
-        "vmware ext license_mgr remove lic retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
-    )
+    ## log.debug(
+    ##     f"vmware ext license_mgr remove lic retrieved service_instance, with opts '{__opts__}', pillar '{__pillar__}'"
+    ## )
 
     if not utils_license_mgr.is_vcenter(service_instance):
         ret["comment"] = "Failed, not connected to a vCenter"
@@ -217,12 +226,12 @@ def remove(license, **kwargs):
 
     try:
         if "test" in __opts__ and __opts__["test"]:
-            ret["licenses"] = license
+            ret["licenses"] = license_key
             ret["comment"] = "Test dry-run, not really connected to a vCenter testing"
             return ret
 
         result = utils_license_mgr.remove_license(
-            service_instance, license, datacenter_name, cluster_name, esxi_hostname
+            service_instance, license_key, datacenter_name, cluster_name, esxi_hostname
         )
     except (
         salt.exceptions.VMwareApiError,

--- a/src/saltext/vmware/states/datacenter.py
+++ b/src/saltext/vmware/states/datacenter.py
@@ -1,3 +1,4 @@
+# Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import logging
 

--- a/src/saltext/vmware/states/license_mgr.py
+++ b/src/saltext/vmware/states/license_mgr.py
@@ -23,12 +23,24 @@ def __virtual__():
     return __virtualname__
 
 
-def absent(license_key):
+def absent(license_key, datacenter_name=None, cluster_name=None, esxi_hostname=None):
     """
-    Remove a license
+    Remove a license from specified Cluster, ESXI Server or vCenter
+    If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
     license
-        License Key to remove form license manager
+        License Key to remove from license manager
+
+    datacenter_name
+        Datacenter name to use for the operation [default None]
+
+    cluster_name
+        Name of the cluster from which to remove license [default None]
+
+    esxi_hostname
+        Hostname of the ESXI Server from which to remove the license [default None]
+
+    CLI Example:
 
     .. code-block:: yaml
 
@@ -37,23 +49,38 @@ def absent(license_key):
         - license: license_key
 
     """
-    ret = __salt__["vmware_license_mgr.remove"](license_key)
+    ret = __salt__["vmware_license_mgr.remove"](
+        license_key, datacenter_name, cluster_name, esxi_hostname
+    )
     return ret
 
 
-def present(license_key):
+def present(license_key, datacenter_name=None, cluster_name=None, esxi_hostname=None):
     """
-    Remove a license
+    Add a license to specified Cluster, ESXI Server or vCenter
+    If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
     license
         License Key to add to license manager
 
+    datacenter_name
+        Datacenter name to use for the operation [default None]
+
+    cluster_name
+        Name of the cluster to add license [default None]
+
+    esxi_hostname
+        Hostname of the ESXI Server to add license [default None]
+
+    CLI Example:
 
     .. code-block:: yaml
 
-    Remove license from License Manager:
+    Add license to License Manager:
       vmware_license_mgr.present:
         - license: license_key
     """
-    ret = __salt__["vmware_license_mgr.add"](license_key)
+    ret = __salt__["vmware_license_mgr.add"](
+        license_key, datacenter_name, cluster_name, esxi_hostname
+    )
     return ret

--- a/src/saltext/vmware/states/license_mgr.py
+++ b/src/saltext/vmware/states/license_mgr.py
@@ -80,11 +80,5 @@ def present(license_key, **kwargs):
         - license: license_key
         - datacenter_name: dc1
     """
-    ret = __salt__["vmware_license_mgr.list"]()
-    if license_key in ret["licenses"]:
-        ret["message"] = f"License key '{license_key}' is already present. No changes made"
-        ret["result"] = True
-        return ret
-
     ret = __salt__["vmware_license_mgr.add"](license_key, **kwargs)
     return ret

--- a/src/saltext/vmware/states/license_mgr.py
+++ b/src/saltext/vmware/states/license_mgr.py
@@ -23,90 +23,37 @@ def __virtual__():
     return __virtualname__
 
 
-## DGM Don't believe you can create a License Manager - Check TBD
-
-
-def present(name):
+def absent(license_key):
     """
-    Create a license manager
+    Remove a license
+
+    license
+        License Key to remove form license manager
 
     .. code-block:: yaml
 
-    Create license manager:
-      vmware_license_mgr.present:
-        - name: licmgr1
+    Remove license from License Manager:
+      vmware_license_mgr.absent:
+        - license: license_key
 
     """
-    ret = {"name": name, "result": None, "comment": "", "changes": {}}
-    licmgrs = __salt__["vmware_license_mgr.list"]()
-    if name in licmgrs:
-        ret["comment"] = "license manager {} is already present. No changes made.".format(name)
-        ret["result"] = True
-    else:
-        ret["comment"] = "license manager {} not found.".format(name)
-        ret["result"] = False
+    ret = __salt__["vmware_license_mgr.remove"](license_key)
     return ret
 
 
-## def present(name):
-##     """
-##     Create a license manager
-##
-##     .. code-block:: yaml
-##
-##     Create license manager:
-##       vmware_license_mgr.present:
-##         - name: dc1
-##
-##     """
-##     ret = {"name": name, "result": None, "comment": "", "changes": {}}
-##     dcs = __salt__["vmware_license_mgr.list"]()
-##     if name in dcs:
-##         ret["comment"] = "license manager {} is already present. No changes made.".format(name)
-##         ret["result"] = True
-##     elif __opts__["test"]:
-##         ret["comment"] = "license manager {} will be created.".format(name)
-##         ret["result"] = None
-##     else:
-##         dc = __salt__["vmware_license_mgr.create"](name)
-##         if isinstance(dc, dict) and dc.get(name) is not False:
-##             ret["comment"] = "license manager - {} created.".format(name)
-##             ret["changes"] = dc
-##             ret["result"] = True
-##
-##         else:
-##             ret["comment"] = dc["reason"]
-##             ret["result"] = False
-##     return ret
+def present(license_key):
+    """
+    Remove a license
+
+    license
+        License Key to add to license manager
 
 
-## DGM don't believe you can delete a License Manager - Check TBD
-## def absent(name):
-##     """
-##     Delete a license manager.
-##
-##     .. code-block:: yaml
-##
-##     Delete license manager:
-##       vmware_license_mgr.absent:
-##         - name: dc1
-##     """
-##     ret = {"name": name, "result": None, "comment": "", "changes": {}}
-##     dcs = __salt__["vmware_license_mgr.list"]()
-##     if name not in dcs:
-##         ret["comment"] = "license manager {} does not exist. No changes made.".format(name)
-##         ret["result"] = True
-##     elif __opts__["test"]:
-##         ret["comment"] = "license manager {} will be deleted.".format(name)
-##         ret["result"] = None
-##     else:
-##         dc = __salt__["vmware_license_mgr.delete"](name)
-##         if isinstance(dc, dict) and dc.get(name) is not False:
-##             ret["comment"] = "license manager - {} deleted.".format(name)
-##             ret["changes"] = dc
-##             ret["result"] = True
-##
-##         else:
-##             ret["comment"] = dc["reason"]
-##             ret["result"] = False
-##     return ret
+    .. code-block:: yaml
+
+    Remove license from License Manager:
+      vmware_license_mgr.present:
+        - license: license_key
+    """
+    ret = __salt__["vmware_license_mgr.add"](license_key)
+    return ret

--- a/src/saltext/vmware/states/license_mgr.py
+++ b/src/saltext/vmware/states/license_mgr.py
@@ -54,7 +54,7 @@ def absent(license_key, **kwargs):
     return ret
 
 
-def present(license_key, datacenter_name=None, cluster_name=None, esxi_hostname=None):
+def present(license_key, **kwargs):
     """
     Add a license to specified Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
@@ -80,7 +80,11 @@ def present(license_key, datacenter_name=None, cluster_name=None, esxi_hostname=
         - license: license_key
         - datacenter_name: dc1
     """
-    ret = __salt__["vmware_license_mgr.add"](
-        license_key, datacenter_name, cluster_name, esxi_hostname
-    )
+    ret = __salt__["vmware_license_mgr.list"]()
+    if license_key in ret["licenses"]:
+        ret["comment"] = f"License key '{license_key}' is already present. No changes made"
+        ret["result"] = True
+        return ret
+
+    ret = __salt__["vmware_license_mgr.add"](license_key, **kwargs)
     return ret

--- a/src/saltext/vmware/states/license_mgr.py
+++ b/src/saltext/vmware/states/license_mgr.py
@@ -82,7 +82,7 @@ def present(license_key, **kwargs):
     """
     ret = __salt__["vmware_license_mgr.list"]()
     if license_key in ret["licenses"]:
-        ret["comment"] = f"License key '{license_key}' is already present. No changes made"
+        ret["message"] = f"License key '{license_key}' is already present. No changes made"
         ret["result"] = True
         return ret
 

--- a/src/saltext/vmware/states/license_mgr.py
+++ b/src/saltext/vmware/states/license_mgr.py
@@ -23,22 +23,25 @@ def __virtual__():
     return __virtualname__
 
 
-def absent(license_key, datacenter_name=None, cluster_name=None, esxi_hostname=None):
+def absent(license_key, **kwargs):
     """
     Remove a license from specified Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    license
-        License Key to remove from license manager
+    Parameters:
+      Required:
+        * license
+            License Key to remove from license manager
 
-    datacenter_name
-        Datacenter name to use for the operation [default None]
+      Optional:
+        * datacenter_name
+            Datacenter name to use for the operation [default None]
 
-    cluster_name
-        Name of the cluster from which to remove license [default None]
+        * cluster_name
+            Name of the cluster from which to remove license [default None]
 
-    esxi_hostname
-        Hostname of the ESXI Server from which to remove the license [default None]
+        * esxi_hostname
+            Hostname of the ESXI Server from which to remove the license [default None]
 
     CLI Example:
 
@@ -47,11 +50,10 @@ def absent(license_key, datacenter_name=None, cluster_name=None, esxi_hostname=N
     Remove license from License Manager:
       vmware_license_mgr.absent:
         - license: license_key
+        - datacenter_name: dc1
 
     """
-    ret = __salt__["vmware_license_mgr.remove"](
-        license_key, datacenter_name, cluster_name, esxi_hostname
-    )
+    ret = __salt__["vmware_license_mgr.remove"](license_key, **kwargs)
     return ret
 
 
@@ -60,17 +62,20 @@ def present(license_key, datacenter_name=None, cluster_name=None, esxi_hostname=
     Add a license to specified Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    license
-        License Key to add to license manager
+    Parameters:
+      Required:
+        * license
+            License Key to add to license manager
 
-    datacenter_name
-        Datacenter name to use for the operation [default None]
+      Optional:
+        * datacenter_name
+            Datacenter name to use for the operation [default None]
 
-    cluster_name
-        Name of the cluster to add license [default None]
+        * cluster_name
+            Name of the cluster to add license [default None]
 
-    esxi_hostname
-        Hostname of the ESXI Server to add license [default None]
+        * esxi_hostname
+            Hostname of the ESXI Server to add license [default None]
 
     CLI Example:
 
@@ -79,6 +84,7 @@ def present(license_key, datacenter_name=None, cluster_name=None, esxi_hostname=
     Add license to License Manager:
       vmware_license_mgr.present:
         - license: license_key
+        - datacenter_name: dc1
     """
     ret = __salt__["vmware_license_mgr.add"](
         license_key, datacenter_name, cluster_name, esxi_hostname

--- a/src/saltext/vmware/states/license_mgr.py
+++ b/src/saltext/vmware/states/license_mgr.py
@@ -25,11 +25,11 @@ def __virtual__():
 
 def absent(license_key, **kwargs):
     """
-    Remove a license from specified Cluster, ESXI Server or vCenter
+    Remove a license specified by license_key from a Datacenter, Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
     license
-        License Key to remove from license manager
+        License Key which specifies license to remove from license manager
 
     datacenter_name
         Datacenter name to use for the operation [default None]
@@ -56,11 +56,11 @@ def absent(license_key, **kwargs):
 
 def present(license_key, **kwargs):
     """
-    Add a license to specified Cluster, ESXI Server or vCenter
+    Add a license specified by license key to a Datacenter, Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    license
-        License Key to add to license manager
+    license_key
+        License Key which specifies license to add to license manager
 
     datacenter_name
         Datacenter name to use for the operation [default None]

--- a/src/saltext/vmware/states/license_mgr.py
+++ b/src/saltext/vmware/states/license_mgr.py
@@ -28,20 +28,17 @@ def absent(license_key, **kwargs):
     Remove a license from specified Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    Parameters:
-      Required:
-        * license
-            License Key to remove from license manager
+    license
+        License Key to remove from license manager
 
-      Optional:
-        * datacenter_name
-            Datacenter name to use for the operation [default None]
+    datacenter_name
+        Datacenter name to use for the operation [default None]
 
-        * cluster_name
-            Name of the cluster from which to remove license [default None]
+    cluster_name
+        Name of the cluster from which to remove license [default None]
 
-        * esxi_hostname
-            Hostname of the ESXI Server from which to remove the license [default None]
+    esxi_hostname
+        Hostname of the ESXI Server from which to remove the license [default None]
 
     CLI Example:
 
@@ -62,20 +59,17 @@ def present(license_key, datacenter_name=None, cluster_name=None, esxi_hostname=
     Add a license to specified Cluster, ESXI Server or vCenter
     If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
 
-    Parameters:
-      Required:
-        * license
-            License Key to add to license manager
+    license
+        License Key to add to license manager
 
-      Optional:
-        * datacenter_name
-            Datacenter name to use for the operation [default None]
+    datacenter_name
+        Datacenter name to use for the operation [default None]
 
-        * cluster_name
-            Name of the cluster to add license [default None]
+    cluster_name
+        Name of the cluster to add license [default None]
 
-        * esxi_hostname
-            Hostname of the ESXI Server to add license [default None]
+    esxi_hostname
+        Hostname of the ESXI Server to add license [default None]
 
     CLI Example:
 

--- a/src/saltext/vmware/states/license_mgr.py
+++ b/src/saltext/vmware/states/license_mgr.py
@@ -1,0 +1,112 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+
+log = logging.getLogger(__name__)
+
+try:
+    import pyVmomi
+
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+
+__virtualname__ = "vmware_license_mgr"
+__proxyenabled__ = ["vmware_license_mgr"]
+
+
+def __virtual__():
+    if not HAS_PYVMOMI:
+        return False, "Unable to import pyVmomi module."
+    return __virtualname__
+
+
+## DGM Don't believe you can create a License Manager - Check TBD
+
+
+def present(name):
+    """
+    Create a license manager
+
+    .. code-block:: yaml
+
+    Create license manager:
+      vmware_license_mgr.present:
+        - name: licmgr1
+
+    """
+    ret = {"name": name, "result": None, "comment": "", "changes": {}}
+    licmgrs = __salt__["vmware_license_mgr.list"]()
+    if name in licmgrs:
+        ret["comment"] = "license manager {} is already present. No changes made.".format(name)
+        ret["result"] = True
+    else:
+        ret["comment"] = "license manager {} not found.".format(name)
+        ret["result"] = False
+    return ret
+
+
+## def present(name):
+##     """
+##     Create a license manager
+##
+##     .. code-block:: yaml
+##
+##     Create license manager:
+##       vmware_license_mgr.present:
+##         - name: dc1
+##
+##     """
+##     ret = {"name": name, "result": None, "comment": "", "changes": {}}
+##     dcs = __salt__["vmware_license_mgr.list"]()
+##     if name in dcs:
+##         ret["comment"] = "license manager {} is already present. No changes made.".format(name)
+##         ret["result"] = True
+##     elif __opts__["test"]:
+##         ret["comment"] = "license manager {} will be created.".format(name)
+##         ret["result"] = None
+##     else:
+##         dc = __salt__["vmware_license_mgr.create"](name)
+##         if isinstance(dc, dict) and dc.get(name) is not False:
+##             ret["comment"] = "license manager - {} created.".format(name)
+##             ret["changes"] = dc
+##             ret["result"] = True
+##
+##         else:
+##             ret["comment"] = dc["reason"]
+##             ret["result"] = False
+##     return ret
+
+
+## DGM don't believe you can delete a License Manager - Check TBD
+## def absent(name):
+##     """
+##     Delete a license manager.
+##
+##     .. code-block:: yaml
+##
+##     Delete license manager:
+##       vmware_license_mgr.absent:
+##         - name: dc1
+##     """
+##     ret = {"name": name, "result": None, "comment": "", "changes": {}}
+##     dcs = __salt__["vmware_license_mgr.list"]()
+##     if name not in dcs:
+##         ret["comment"] = "license manager {} does not exist. No changes made.".format(name)
+##         ret["result"] = True
+##     elif __opts__["test"]:
+##         ret["comment"] = "license manager {} will be deleted.".format(name)
+##         ret["result"] = None
+##     else:
+##         dc = __salt__["vmware_license_mgr.delete"](name)
+##         if isinstance(dc, dict) and dc.get(name) is not False:
+##             ret["comment"] = "license manager - {} deleted.".format(name)
+##             ret["changes"] = dc
+##             ret["result"] = True
+##
+##         else:
+##             ret["comment"] = dc["reason"]
+##             ret["result"] = False
+##     return ret

--- a/src/saltext/vmware/utils/common.py
+++ b/src/saltext/vmware/utils/common.py
@@ -1,3 +1,4 @@
+# Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """
 Common functions used across modules
@@ -213,6 +214,8 @@ def get_mors_with_properties(
         Flag specigying whether the properties to be retrieved are local to the
         container. If that is the case, the traversal spec needs to be None.
     """
+    log.debug("start get_mors_with_properties")
+
     # Get all the content
     content_args = [service_instance, object_type]
     content_kwargs = {
@@ -230,12 +233,16 @@ def get_mors_with_properties(
             raise
         content = get_content(*content_args, **content_kwargs)
 
+    log.debug("get_mors_with_properties, get object_list")
     object_list = []
     for obj in content:
         properties = {}
+        log.debug("get_mors_with_properties, get properites from object")
         for prop in obj.propSet:
             properties[prop.name] = prop.val
+        log.debug("get_mors_with_properties, update properites for object")
         properties["object"] = obj.obj
+        log.debug("get_mors_with_properties, append properites to object_list")
         object_list.append(properties)
     log.trace("Retrieved %s objects", len(object_list))
     return object_list
@@ -304,6 +311,7 @@ def list_objects(service_instance, vim_object, properties=None):
     items = []
     item_list = get_mors_with_properties(service_instance, vim_object, properties)
     for item in item_list:
+        log.debug(f"appending item '{name}' to list of objects to return")
         items.append(item["name"])
     return items
 
@@ -791,3 +799,60 @@ def datastore_exit_maintenance_mode(datastore_ref):
     if datastore_ref.summary.maintenanceMode == "normal":
         return True
     return False
+
+
+def get_license_mgrs(service_instance, license_mgr_names=None, get_all_license_mgrs=False):
+    """
+    Returns all license managers in a vCenter.
+
+    service_instance
+        The Service Instance Object from which to obtain cluster.
+
+    license_mgr_names
+        List of license manager names to filter by. Default value is None.
+
+    get_all_license_mgrs
+        Flag specifying whether to retrieve all license managers.
+        Default value is None.
+    """
+    log.debug("started get all License Managers")
+    items = [
+        i["object"]
+        for i in get_mors_with_properties(
+            service_instance, vim.LicenseAssignmentManager, property_list=["name"]
+        )
+        if get_all_license_mgrs or (license_mgr_names and i["name"] in license_mgr_names)
+    ]
+    log.debug("exited get all License Managers")
+    return items
+
+
+def get_license_mgr(service_instance, license_mgr_name):
+    """
+    Returns a vim.LicenseAssignmentManager managed object.
+
+    service_instance
+        The Service Instance Object from which to obtain license manager.
+
+    license_mgr_name
+        The license manager name
+    """
+    log.debug(f"started get License Manager '{license_mgr_name}'")
+    items = get_license_mgrs(service_instance, license_mgr_names=[license_mgr_name])
+    if not items:
+        raise salt.exceptions.VMwareObjectRetrievalError(
+            f"license manager '{license_mgr_name}' was not found"
+        )
+    log.debug(f"exit License Manager '{license_mgr_name}'")
+    return items[0]
+
+
+def list_license_mgrs(service_instance):
+    """
+    Returns a list of license managers associated with a given service instance.
+
+    service_instance
+        The Service Instance Object from which to obtain license managers.
+    """
+    log.debug("start list of License Managers")
+    return list_objects(service_instance, vim.LicenseAssignmentManager)

--- a/src/saltext/vmware/utils/common.py
+++ b/src/saltext/vmware/utils/common.py
@@ -40,7 +40,6 @@ def get_root_folder(service_instance):
         The Service Instance Object for which to obtain the root folder.
 
     """
-    log.debug("start get_root_folder")
     try:
         log.trace("Retrieving root folder")
         return service_instance.RetrieveContent().rootFolder
@@ -64,7 +63,6 @@ def get_service_content(service_instance):
     service_instance
         The Service Instance from which to obtain service content.
     """
-    log.debug("start get_service_content")
     try:
         return service_instance.RetrieveServiceContent()
     except vim.fault.NoPermission as exc:
@@ -116,8 +114,6 @@ def get_content(
         Flag specifying whether the properties to be retrieved are local to the
         container. If that is the case, the traversal spec needs to be None.
     """
-    log.debug("start get_content")
-
     # Start at the rootFolder if container starting point not specified
     if not container_ref:
         container_ref = get_root_folder(service_instance)
@@ -241,8 +237,6 @@ def get_mors_with_properties(
         Flag specifying whether the properties to be retrieved are local to the
         container. If that is the case, the traversal spec needs to be None.
     """
-    log.debug("start get_mors_with_properties")
-
     # Get all the content
     content_args = [service_instance, object_type]
     content_kwargs = {
@@ -260,16 +254,12 @@ def get_mors_with_properties(
             raise
         content = get_content(*content_args, **content_kwargs)
 
-    log.debug("get_mors_with_properties, get object_list")
     object_list = []
     for obj in content:
         properties = {}
-        log.debug("get_mors_with_properties, get properites from object")
         for prop in obj.propSet:
             properties[prop.name] = prop.val
-        log.debug("get_mors_with_properties, update properites for object")
         properties["object"] = obj.obj
-        log.debug("get_mors_with_properties, append properites to object_list")
         object_list.append(properties)
     log.trace("Retrieved %s objects", len(object_list))
     return object_list

--- a/src/saltext/vmware/utils/common.py
+++ b/src/saltext/vmware/utils/common.py
@@ -38,7 +38,9 @@ def get_root_folder(service_instance):
 
     service_instance
         The Service Instance Object for which to obtain the root folder.
+
     """
+    log.debug("start get_root_folder")
     try:
         log.trace("Retrieving root folder")
         return service_instance.RetrieveContent().rootFolder
@@ -46,6 +48,29 @@ def get_root_folder(service_instance):
         log.exception(exc)
         raise salt.exceptions.VMwareApiError(
             "Not enough permissions. Required privilege: " "{}".format(exc.privilegeId)
+        )
+    except vim.fault.VimFault as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareApiError(exc.msg)
+    except vmodl.RuntimeFault as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareRuntimeError(exc.msg)
+
+
+def get_service_content(service_instance):
+    """
+    Returns the service content for a Service Instance.
+
+    service_instance
+        The Service Instance from which to obtain service content.
+    """
+    log.debug("start get_service_content")
+    try:
+        return service_instance.RetrieveServiceContent()
+    except vim.fault.NoPermission as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareApiError(
+            f"Not enough permissions. Required privilege: '{exc.privilegeId}'"
         )
     except vim.fault.VimFault as exc:
         log.exception(exc)
@@ -91,6 +116,8 @@ def get_content(
         Flag specifying whether the properties to be retrieved are local to the
         container. If that is the case, the traversal spec needs to be None.
     """
+    log.debug("start get_content")
+
     # Start at the rootFolder if container starting point not specified
     if not container_ref:
         container_ref = get_root_folder(service_instance)
@@ -211,7 +238,7 @@ def get_mors_with_properties(
         ``Traverse All`` spec
 
     local_properties
-        Flag specigying whether the properties to be retrieved are local to the
+        Flag specifying whether the properties to be retrieved are local to the
         container. If that is the case, the traversal spec needs to be None.
     """
     log.debug("start get_mors_with_properties")

--- a/src/saltext/vmware/utils/common.py
+++ b/src/saltext/vmware/utils/common.py
@@ -328,7 +328,7 @@ def list_objects(service_instance, vim_object, properties=None):
     items = []
     item_list = get_mors_with_properties(service_instance, vim_object, properties)
     for item in item_list:
-        log.debug(f"appending item '{name}' to list of objects to return")
+        log.debug(f"appending item '{name!r}' to list of objects to return")
         items.append(item["name"])
     return items
 

--- a/src/saltext/vmware/utils/datacenter.py
+++ b/src/saltext/vmware/utils/datacenter.py
@@ -1,3 +1,4 @@
+# Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 # pylint: disable=no-name-in-module
 import logging

--- a/src/saltext/vmware/utils/license_mgr.py
+++ b/src/saltext/vmware/utils/license_mgr.py
@@ -91,7 +91,7 @@ def _get_entity_id(service_instance, datacenter_name, cluster_name, esxi_hostnam
 
     _entity_id = None  # TBD miracle happens here and have value
     datacenter_ref = None
-    if not any(datacenter_name or cluster_name or esxi_hostname):
+    if not any((datacenter_name, cluster_name, esxi_hostname)):
         # default to applying to vCenter
         srv_content = get_service_content(service_instance)
         _entity_id = srv_content.about.instanceUuid

--- a/src/saltext/vmware/utils/license_mgr.py
+++ b/src/saltext/vmware/utils/license_mgr.py
@@ -3,15 +3,16 @@
 # pylint: disable=no-name-in-module
 import logging
 
+import saltext.vmware.utils.cluster as utils_cluster
+import saltext.vmware.utils.datacenter as utils_datacenter
+import saltext.vmware.utils.esxi as utils_esxi
+from saltext.vmware.utils.common import get_service_content as get_service_content
+
 import salt.exceptions
 import salt.modules.cmdmod
 import salt.utils.path
 import salt.utils.platform
 import salt.utils.stringutils
-import saltext.vmware.utils.cluster as utils_cluster
-import saltext.vmware.utils.datacenter as utils_datacenter
-import saltext.vmware.utils.esxi as utils_esxi
-from saltext.vmware.utils.common import get_service_content as get_service_content
 
 try:
     from pyVmomi import vim, vmodl
@@ -123,6 +124,7 @@ def list_licenses(service_instance):
     ret = {}
     lic_mgr = get_license_mgr(service_instance)
     log.debug(f"listing licenses from License Manager '{lic_mgr}'")
+
     if not lic_mgr:
         ret["comment"] = "Failed, not connected to a vCenter"
         ret["result"] = False
@@ -285,6 +287,7 @@ def remove_license(
     # TBD need to determine if can 'RemoveAssignedLicense' or if simple
     # 'RemoveLicense' will unassign any assigned licenses when the license
     # is removed
+
     try:
         lic_mgr.RemoveLicense(licenseKey=license)
     except vim.fault.VimFault as exc:

--- a/src/saltext/vmware/utils/license_mgr.py
+++ b/src/saltext/vmware/utils/license_mgr.py
@@ -153,10 +153,10 @@ def is_vcenter(service_instance):
         raise salt.exceptions.VMwareRuntimeError(exc.msg)
     except AttributeError as exc:
         log.exception(exc)
-        raise salt.exceptions.CommandExecutionError(exc.msg)
+        raise salt.exceptions.CommandExecutionError(exc)
     except TypeError as exc:
         log.exception(exc)
-        raise salt.exceptions.CommandExecutionError(exc.msg)
+        raise salt.exceptions.CommandExecutionError(exc)
 
     if apitype == "VirtualCenter":
         return True
@@ -185,6 +185,8 @@ def get_license_mgr(service_instance):
 def get_license_assignment_mgr(service_instance):
     """
     Return a license assignment manager from specified Service Instance
+    if the Service Instance is connected to a vCenter,
+    otherwise return None
 
     service_instance
         vCenter service connection instance
@@ -195,7 +197,7 @@ def get_license_assignment_mgr(service_instance):
         return None
 
     srv_content = get_service_content(service_instance)
-    return srv_content.licenseManager
+    return srv_content.licenseManager.licenseAssignmentManager
 
 
 def list_licenses(service_instance):
@@ -287,7 +289,7 @@ def add_license(
             log.debug(
                 f"assigning license, entity identifier '{entity_id}' has assigned license '{assigned_lic}'"
             )
-            # pyvmomi seen doing strange things, hence checking length returned
+            # pyVmomi seen doing strange things, hence checking length returned
             if not assigned_lic or (
                 len(assigned_lic) != 0 and assigned_lic[0].assignedLicense.licenseKey != license_key
             ):
@@ -301,10 +303,10 @@ def add_license(
         raise salt.exceptions.VMwareRuntimeError(exc.msg)
     except AttributeError as exc:
         log.exception(exc)
-        raise salt.exceptions.CommandExecutionError(exc.msg)
+        raise salt.exceptions.CommandExecutionError(exc)
     except TypeError as exc:
         log.exception(exc)
-        raise salt.exceptions.CommandExecutionError(exc.msg)
+        raise salt.exceptions.CommandExecutionError(exc)
 
     return True
 
@@ -373,7 +375,6 @@ def remove_license(
                 log.debug(
                     f"no assigned license found, or the assigned license key for entity identifier '{entity_id}' did not match specified license key"
                 )
-                return False
 
             log.debug(f"Removing license key from License Managers pool of licenses")
             lic_mgr.RemoveLicense(licenseKey=license_key)
@@ -391,9 +392,9 @@ def remove_license(
         raise salt.exceptions.VMwareRuntimeError(exc.msg)
     except AttributeError as exc:
         log.exception(exc)
-        raise salt.exceptions.CommandExecutionError(exc.msg)
+        raise salt.exceptions.CommandExecutionError(exc)
     except TypeError as exc:
         log.exception(exc)
-        raise salt.exceptions.CommandExecutionError(exc.msg)
+        raise salt.exceptions.CommandExecutionError(exc)
 
     return True

--- a/src/saltext/vmware/utils/license_mgr.py
+++ b/src/saltext/vmware/utils/license_mgr.py
@@ -3,16 +3,16 @@
 # pylint: disable=no-name-in-module
 import logging
 
-import saltext.vmware.utils.cluster as utils_cluster
-import saltext.vmware.utils.datacenter as utils_datacenter
-import saltext.vmware.utils.esxi as utils_esxi
-from saltext.vmware.utils.common import get_service_content as get_service_content
-
+# noreorder
 import salt.exceptions
 import salt.modules.cmdmod
 import salt.utils.path
 import salt.utils.platform
 import salt.utils.stringutils
+import saltext.vmware.utils.cluster as utils_cluster
+import saltext.vmware.utils.datacenter as utils_datacenter
+import saltext.vmware.utils.esxi as utils_esxi
+from saltext.vmware.utils.common import get_service_content as get_service_content
 
 try:
     from pyVmomi import vim, vmodl

--- a/src/saltext/vmware/utils/license_mgr.py
+++ b/src/saltext/vmware/utils/license_mgr.py
@@ -8,12 +8,7 @@ import salt.modules.cmdmod
 import salt.utils.path
 import salt.utils.platform
 import salt.utils.stringutils
-from saltext.vmware.utils.common import get_license_mgr as get_license_mgr
-from saltext.vmware.utils.common import get_license_mgrs as get_license_mgrs
-from saltext.vmware.utils.common import list_license_mgrs as list_license_mgrs
-
-## from saltext.vmware.utils.common import create_datacenter as create_datacenter
-## from saltext.vmware.utils.common import delete_datacenter as delete_datacenter
+from saltext.vmware.utils.common import get_service_content as get_service_content
 
 try:
     from pyVmomi import vim, vmodl
@@ -25,17 +20,201 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-def get_license_mgr(*, vm):
+def _list_lic_keys(licenses):
     """
-    Return a license manager from vm
+    Return a list of license keys
+
+    licenses:
+       vCenter licenses as made available from licenseAssignmentManager
+
+    Note:
+        skips evaluation licenses
+    """
+    log.debug("started _list_lic_keys")
+    lic_keys = []
+    for lic in licenses:
+        if lic.used is None:
+            continue
+        lic_keys.append(lic.licenseKey)
+    return lic_keys
+
+
+def is_vcenter(service_instance):
+    """
+    Test if service_instance represents vCenter,
+    otherwise assume represents an ESXi server
+
+    service_instance
+        The Service Instance to check if it represents a vCenter
+
+    Return:
+        True  - vCenter
+        False - ESXi server
+        None - neither of the above
+    """
+    try:
+        srv_content = get_service_content(service_instance)
+        apitype = srv_content.about.apiType
+    except vim.fault.VimFault as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareApiError(exc.msg)
+    except vmodl.RuntimeFault as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareRuntimeError(exc.msg)
+
+    if apitype == "VirtualCenter":
+        return True
+    elif apitype == "HostAgent":
+        return False
+
+    return None
+
+
+def get_license_mgr(service_instance):
+    """
+    Return a license manager from specified Service Instance
+
+    Note: returns LicenseManager
     """
     lic_mgr = None
-    while True:
-        if isinstance(vm, vim.LicenseAssignmentManager):
-            lic_mgr = vm
-            break
-        try:
-            vm = vm.parent
-        except AttributeError:
-            break
+
+    if not is_vcenter(service_instance):
+        return lic_mgr
+
+    srv_content = get_service_content(service_instance)
+    lic_mgr = srv_content.licenseManager
     return lic_mgr
+
+
+def get_license_assignment_mgr(service_instance):
+    """
+    Return a license assignment manager from specified Service Instance
+
+    Note: returns LicenseAssignmentManager
+    """
+    lic_mgr = None
+
+    if not is_vcenter(service_instance):
+        return lic_mgr
+
+    srv_content = get_service_content(service_instance)
+    lic_mgr = srv_content.licenseManager.licenseAssignmentManager
+    return lic_mgr
+
+
+def list_licenses(service_instance):
+    """
+    Returns a list of licenses associated with specified Service Instance.
+
+    service_instance
+        The Service Instance Object from which to obtain licenses.
+    """
+    log.debug("start list of License Managers")
+
+    ret = {}
+    lic_mgr = get_license_mgr(service_instance)
+    log.debug(f"listing licenses from License Manager '{lic_mgr}'")
+    if not lic_mgr:
+        ret["comment"] = "Failed, not connected to a vCenter"
+        ret["result"] = False
+        return ret
+
+    ret["licenses"] = _list_lic_keys(lic_mgr.licenses)
+    return ret
+
+
+def add_license(service_instance, license):
+    """
+    Add a license to the License Manager associated with the specified Service Instance
+    Adds the license to the pool of available licenses associated with the License Manager
+
+    service_instance:
+        Service Instance containing a License Manager
+
+    license
+        License to add to the license manager
+
+    Returns:
+        True - if successful or license already present
+    """
+    lic_mgr = get_license_mgr(service_instance)
+    if not lic_mgr:
+        return False
+
+    lic_keys = _list_lic_keys(lic_mgr.licenses)
+    log.debug(
+        f"attempting to add license '{license}' to list of existing license keys '{lic_keys}'"
+    )
+
+    try:
+        if not license in lic_keys:
+            lic_mgr.AddLicense(licenseKey=license)
+
+        # need to extract entity this license is intended for so that it can be assigned.
+        # choices are:
+        #   1 vCenter - entity_id = service_instance.content.about.instanceUuid
+        #   2 ESXi - entity_id = esxi host _moId, need to check it is for an 'esx' license.editionKey
+        #   3 cluster - entity_id = cluster _moId
+
+        entity_id = None  # TBD miracle happens here and have value
+
+        # TBD do vCenter for now
+        srv_content = get_service_content(service_instance)
+        entity_id = srv_content.about.instanceUuid
+        lic_assign_mgr = get_license_assignment_mgr(service_instance)
+        if entity_id:
+            assigned_lic = lic_assign_mgr.QueryAssignedLicenses(entityId=entity_id)
+
+            log.debug(
+                "assigning license, entity identifier '{entity_id}' has assigned license '{assigned_lic}'"
+            )
+            if not assigned_lic or (
+                len(assigned_lic) != 0 and assigned_lic[0].assignedLicense.licenseKey != license
+            ):
+                lic_assign_mgr.UpdateAssignedLicense(entity=entity_id, licenseKey=license)
+
+    except vim.fault.VimFault as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareApiError(exc.msg)
+    except vmodl.RuntimeFault as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareRuntimeError(exc.msg)
+
+    return True
+
+
+def remove_license(service_instance, license):
+    """
+    Remove specified license from the License Manager associated with the specified Service Instance
+    Removes the license from the pool of available licenses associated with the License Manager
+
+    service_instance:
+        Service Instance containing a License Manager
+
+    license
+        License to remove from the license manager
+
+    Returns:
+        True - if successful or license already present
+    """
+    lic_mgr = get_license_mgr(service_instance)
+    if not lic_mgr:
+        return False
+
+    lic_keys = _list_lic_keys(lic_mgr.licenses)
+    log.debug(
+        f"attempting to remove license '{license}' from list of existing license keys '{lic_keys}'"
+    )
+    if license not in lic_keys:
+        return False
+
+    try:
+        lic_mgr.RemoveLicense(licenseKey=license)
+    except vim.fault.VimFault as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareApiError(exc.msg)
+    except vmodl.RuntimeFault as exc:
+        log.exception(exc)
+        raise salt.exceptions.VMwareRuntimeError(exc.msg)
+
+    return True

--- a/src/saltext/vmware/utils/license_mgr.py
+++ b/src/saltext/vmware/utils/license_mgr.py
@@ -201,10 +201,7 @@ def add_license(
 
     try:
         if not license_key in lic_keys:
-            ##  lic_mgr.AddLicense(licenseKey=license_key)
-            dgm_test = True
-            if dgm_test:
-                lic_mgr.AddLicense(licenseKey=license_key)
+            lic_mgr.AddLicense(licenseKey=license_key)
 
         # get license just added for specified license key
         addedLic = _find_lic_for_key(lic_mgr.licenses, license_key)

--- a/src/saltext/vmware/utils/license_mgr.py
+++ b/src/saltext/vmware/utils/license_mgr.py
@@ -149,7 +149,7 @@ def list_licenses(service_instance):
     log.debug(f"License Manager listing of licenses '{lic_mgr.licenses}'")
 
     if not lic_mgr:
-        ret["comment"] = "Failed, not connected to a vCenter"
+        ret["message"] = "Failed, not connected to a vCenter"
         ret["result"] = False
         return ret
 

--- a/src/saltext/vmware/utils/license_mgr.py
+++ b/src/saltext/vmware/utils/license_mgr.py
@@ -34,7 +34,6 @@ def _list_lic_keys(licenses):
     Note:
         skips evaluation licenses
     """
-    log.debug("started _list_lic_keys")
     lic_keys = []
     for lic in licenses:
         if lic.used is None:
@@ -56,7 +55,6 @@ def _find_lic_for_key(licenses, license_key):
     Note:
         skips evaluation licenses
     """
-    log.debug("started _find_lic_for_key")
     lic_keys = []
     for lic in licenses:
         if lic.used is None:
@@ -69,14 +67,13 @@ def _find_lic_for_key(licenses, license_key):
 def is_vcenter(service_instance):
     """
     Test if service_instance represents vCenter,
-    otherwise assume represents an ESXi server
 
     service_instance
         The Service Instance to check if it represents a vCenter
 
     Return:
         True  - vCenter
-        False - ESXi server
+        False - not a vCenter
         None - neither of the above
     """
     try:
@@ -97,10 +94,8 @@ def is_vcenter(service_instance):
 
     if apitype == "VirtualCenter":
         return True
-    elif apitype == "HostAgent":
-        return False
 
-    return None
+    return False
 
 
 def get_license_mgr(service_instance):
@@ -112,14 +107,11 @@ def get_license_mgr(service_instance):
 
     Note: returns LicenseManager
     """
-    lic_mgr = None
-
     if not is_vcenter(service_instance):
-        return lic_mgr
+        return None
 
     srv_content = get_service_content(service_instance)
-    lic_mgr = srv_content.licenseManager
-    return lic_mgr
+    return srv_content.licenseManager
 
 
 def get_license_assignment_mgr(service_instance):
@@ -131,14 +123,11 @@ def get_license_assignment_mgr(service_instance):
 
     Note: returns LicenseAssignmentManager
     """
-    lic_mgr = None
-
     if not is_vcenter(service_instance):
-        return lic_mgr
+        return None
 
     srv_content = get_service_content(service_instance)
-    lic_mgr = srv_content.licenseManager.licenseAssignmentManager
-    return lic_mgr
+    return srv_content.licenseManager
 
 
 def list_licenses(service_instance):
@@ -148,8 +137,6 @@ def list_licenses(service_instance):
     service_instance
         The Service Instance Object from which to obtain licenses.
     """
-    log.debug("start list of License Managers")
-
     ret = {}
     lic_mgr = get_license_mgr(service_instance)
     log.debug(f"License Manager listing of licenses '{lic_mgr.licenses}'")
@@ -168,9 +155,9 @@ def add_license(
 ):
     """
     Add license to the pool of available licenses associated with the License Manager
-    and assign it to the specified Cluster, ESXI Server or vCenter
+    and assign it to the specified Cluster, ESXi Server or vCenter
 
-    If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
+    If no datacenter, cluster or ESXi Server is specified, it is assumed the operation is to be applied to a vCenter
 
     service_instance:
         Service Instance containing a License Manager
@@ -185,7 +172,7 @@ def add_license(
         Name of the cluster to add license [default None]
 
     esxi_hostname
-        Hostname of the ESXI Server to add license [default None]
+        Hostname of the ESXi Server to add license [default None]
 
     Returns:
         True - if successful or license already present
@@ -311,9 +298,9 @@ def remove_license(
 ):
     """
     Remove license from the pool of available licenses associated with the License Manager
-    and unassign it from the specified Cluster, ESXI Server or vCenter
+    and unassign it from the specified Cluster, ESXi Server or vCenter
 
-    If no datacenter, cluster or ESXI Server is specified, it is assumed the operation is to be applied to a vCenter
+    If no datacenter, cluster or ESXi Server is specified, it is assumed the operation is to be applied to a vCenter
 
     service_instance:
         Service Instance containing a License Manager
@@ -328,7 +315,7 @@ def remove_license(
         Name of the cluster to add license [default None]
 
     esxi_hostname
-        Hostname of the ESXI Server to add license [default None]
+        Hostname of the ESXi Server to add license [default None]
 
     Returns:
         True - if successful, license removed

--- a/src/saltext/vmware/utils/license_mgr.py
+++ b/src/saltext/vmware/utils/license_mgr.py
@@ -1,0 +1,41 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# pylint: disable=no-name-in-module
+import logging
+
+import salt.exceptions
+import salt.modules.cmdmod
+import salt.utils.path
+import salt.utils.platform
+import salt.utils.stringutils
+from saltext.vmware.utils.common import get_license_mgr as get_license_mgr
+from saltext.vmware.utils.common import get_license_mgrs as get_license_mgrs
+from saltext.vmware.utils.common import list_license_mgrs as list_license_mgrs
+
+## from saltext.vmware.utils.common import create_datacenter as create_datacenter
+## from saltext.vmware.utils.common import delete_datacenter as delete_datacenter
+
+try:
+    from pyVmomi import vim, vmodl
+
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+log = logging.getLogger(__name__)
+
+
+def get_license_mgr(*, vm):
+    """
+    Return a license manager from vm
+    """
+    lic_mgr = None
+    while True:
+        if isinstance(vm, vim.LicenseAssignmentManager):
+            lic_mgr = vm
+            break
+        try:
+            vm = vm.parent
+        except AttributeError:
+            break
+    return lic_mgr

--- a/src/saltext/vmware/utils/license_mgr.py
+++ b/src/saltext/vmware/utils/license_mgr.py
@@ -287,7 +287,7 @@ def add_license(
             log.debug(
                 f"assigning license, entity identifier '{entity_id}' has assigned license '{assigned_lic}'"
             )
-            # pyvnomi seen doing strange things, hence checking length returned
+            # pyvmomi seen doing strange things, hence checking length returned
             if not assigned_lic or (
                 len(assigned_lic) != 0 and assigned_lic[0].assignedLicense.licenseKey != license_key
             ):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,15 +16,15 @@ import saltext.vmware.modules.datacenter as datacenter_mod
 import saltext.vmware.modules.datastore as datastore
 import saltext.vmware.modules.esxi as esxi_mod
 import saltext.vmware.modules.folder as folder
-import saltext.vmware.modules.tag as tagging
 import saltext.vmware.modules.license_mgr as license_mgr_mod
+import saltext.vmware.modules.tag as tagging
 import saltext.vmware.modules.vm as virtual_machine
 import saltext.vmware.states.datacenter as datacenter_st
 import saltext.vmware.states.datastore as datastore_state
 import saltext.vmware.states.esxi as esxi_st
 import saltext.vmware.states.folder as folder_state
-import saltext.vmware.states.tag as tagging_state
 import saltext.vmware.states.license_mgr as license_mgr_st
+import saltext.vmware.states.tag as tagging_state
 import saltext.vmware.states.vm as virtual_machine_state
 from saltext.vmware.utils.connect import get_service_instance
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,12 +17,14 @@ import saltext.vmware.modules.datastore as datastore
 import saltext.vmware.modules.esxi as esxi_mod
 import saltext.vmware.modules.folder as folder
 import saltext.vmware.modules.tag as tagging
+import saltext.vmware.modules.license_mgr as license_mgr_mod
 import saltext.vmware.modules.vm as virtual_machine
 import saltext.vmware.states.datacenter as datacenter_st
 import saltext.vmware.states.datastore as datastore_state
 import saltext.vmware.states.esxi as esxi_st
 import saltext.vmware.states.folder as folder_state
 import saltext.vmware.states.tag as tagging_state
+import saltext.vmware.states.license_mgr as license_mgr_st
 import saltext.vmware.states.vm as virtual_machine_state
 from saltext.vmware.utils.connect import get_service_instance
 
@@ -91,6 +93,10 @@ def patch_salt_globals():
     setattr(cluster_drs_mod, "__pillar__", {})
     setattr(esxi_mod, "__pillar__", {})
     setattr(esxi_st, "__pillar__", {})
+    setattr(license_mgr_st, "__opts__", {})
+    setattr(license_mgr_st, "__pillar__", {})
+    setattr(license_mgr_mod, "__opts__", {})
+    setattr(license_mgr_mod, "__pillar__", {})
     setattr(
         datacenter_st,
         "__salt__",
@@ -135,6 +141,24 @@ def patch_salt_globals():
             "vmware_esxi.update_role": esxi_mod.update_role,
             "vmware_esxi.remove_role": esxi_mod.remove_role,
             "vmware_esxi.get_role": esxi_mod.get_role,
+        },
+    )
+    setattr(
+        license_mgr_st,
+        "__salt__",
+        {
+            "vmware_license_mgr.list": license_mgr_mod.list_,
+            "vmware_license_mgr.add": license_mgr_mod.add,
+            "vmware_license_mgr.remove": license_mgr_mod.remove,
+        },
+    )
+    setattr(
+        license_mgr_mod,
+        "__salt__",
+        {
+            "vmware_license_mgr.list": license_mgr_mod.list_,
+            "vmware_license_mgr.add": license_mgr_mod.add,
+            "vmware_license_mgr.remove": license_mgr_mod.remove,
         },
     )
 
@@ -368,3 +392,26 @@ def vmware_conf(integration_test_config):
 @pytest.fixture()
 def vm_ops():
     return {"test": False}
+
+
+@pytest.fixture(scope="function")
+def vmware_license_mgr_inst(patch_salt_globals, service_instance):
+    """
+    Return a vmware_license_mgr during start of a test and tear it down once the test ends
+
+    vmware_license_mgr is essentially a service_instance to a vCenter
+    """
+    if not service_instance:
+        lic_mgr = get_service_instance(opts=__opts__, pillar=__pillar__)
+    else:
+        lic_mgr = service_instance
+    yield lic_mgr
+    ## datacenter_mod.delete(name=dc_name, service_instance=service_instance)
+
+
+@pytest.fixture(scope="function")
+def license_key(patch_salt_globals, service_instance):
+    """
+    Return a vmware license key faked for now
+    """
+    return "DGMTT-FAKED-TESTS-LICEN-SE012"

--- a/tests/integration/modules/test_license_mgr.py
+++ b/tests/integration/modules/test_license_mgr.py
@@ -1,0 +1,56 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import uuid
+from unittest.mock import patch
+
+import pytest
+import saltext.vmware.modules.license_mgr as license_mgr_mod
+
+
+@pytest.fixture
+def dry_run():
+    setattr(license_mgr_mod, "__opts__", {"test": True})
+    yield
+    setattr(license_mgr_mod, "__opts__", {"test": False})
+
+
+def test_add(patch_salt_globals, license_key, vmware_license_mgr_inst):
+    """
+    Test scenarios for license_mgr.add module run with existing license key it should have
+    """
+    kwargs = {}
+    kwargs["service_instance"] = vmware_license_mgr_inst
+
+    # license_mgr_mod.add on an existing vCenter. No changes should be made.
+    ret = license_mgr_mod.add(license_key, **kwargs)
+
+    ## TBD need real licenses to play with first
+    ## assert ret["changes"] == {}
+    ## assert "already present. No changes made." in ret["comment"]
+    ## assert ret["result"] is True
+
+
+def test_list(patch_salt_globals, license_key, vmware_license_mgr_inst):
+    """
+    Test scenarios for list licenses on vCenter
+    """
+    # List the vCenter licenses.
+    licenses = license_mgr_mod.list_(service_instance=vmware_license_mgr_inst)
+
+    ## TBD need real licenses to play with first
+    ## assert license_key in licenses
+
+
+def test_remove(patch_salt_globals, license_key, vmware_license_mgr_inst):
+    """
+    Test scenarios for license_mgr.remove module run.
+    """
+    kwargs = {}
+    kwargs["service_instance"] = vmware_license_mgr_inst
+
+    # license_mgr.remove on an existing vCenter. No changes should be made.
+    ret = license_mgr_mod.remove(license_key, **kwargs)
+
+    ## TBD need real licenses to play with first
+    ## assert ret["changes"] == {vmware_license_mgr: True}
+    ## assert ret["result"] is True

--- a/tests/integration/modules/test_license_mgr.py
+++ b/tests/integration/modules/test_license_mgr.py
@@ -8,11 +8,6 @@ from unittest.mock import patch
 import pytest
 import saltext.vmware.modules.license_mgr as license_mgr_mod
 
-from salt.exceptions import VMwareApiError
-from salt.exceptions import VMwareObjectRetrievalError
-from salt.exceptions import VMwareRuntimeError
-
-
 log = logging.getLogger(__name__)
 
 

--- a/tests/integration/modules/test_license_mgr.py
+++ b/tests/integration/modules/test_license_mgr.py
@@ -31,7 +31,7 @@ def test_add(patch_salt_globals, license_key, vmware_license_mgr_inst):
 
     assert (
         ret["message"]
-        == f"Failed specified license key '{license_key}' was not added to License Manager"
+        == f"Failed to add a license key '{license_key}' due to Exception 'License is not valid for this product'"
     )
     assert ret["result"] == False
 

--- a/tests/integration/modules/test_license_mgr.py
+++ b/tests/integration/modules/test_license_mgr.py
@@ -31,7 +31,7 @@ def test_add(patch_salt_globals, license_key, vmware_license_mgr_inst):
 
     assert (
         ret["message"]
-        == f"Failed to add a license key '{license_key}' due to Exception 'License is not valid for this product'"
+        == "Failed to add a license key due to Exception 'License is not valid for this product'"
     )
     assert ret["result"] == False
 
@@ -60,8 +60,5 @@ def test_remove(patch_salt_globals, license_key, vmware_license_mgr_inst):
     # hence using fake which should generate error
     ret = license_mgr_mod.remove(license_key, **kwargs)
 
-    assert (
-        ret["message"]
-        == f"Failed specified license key '{license_key}' was not found in License Manager"
-    )
+    assert ret["message"] == "Failed specified license key was not found in License Manager"
     assert ret["result"] == False

--- a/tests/integration/modules/test_license_mgr.py
+++ b/tests/integration/modules/test_license_mgr.py
@@ -1,10 +1,19 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
+import logging
+import os
 import uuid
 from unittest.mock import patch
 
 import pytest
 import saltext.vmware.modules.license_mgr as license_mgr_mod
+
+from salt.exceptions import VMwareApiError
+from salt.exceptions import VMwareObjectRetrievalError
+from salt.exceptions import VMwareRuntimeError
+
+
+log = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -21,13 +30,15 @@ def test_add(patch_salt_globals, license_key, vmware_license_mgr_inst):
     kwargs = {}
     kwargs["service_instance"] = vmware_license_mgr_inst
 
-    # license_mgr_mod.add on an existing vCenter. No changes should be made.
+    # don't have real license to test with (exposure on public repo)
+    # hence using fake which should generate error
     ret = license_mgr_mod.add(license_key, **kwargs)
 
-    ## TBD need real licenses to play with first
-    ## assert ret["changes"] == {}
-    ## assert "already present. No changes made." in ret["comment"]
-    ## assert ret["result"] is True
+    assert (
+        ret["message"]
+        == f"Failed specified license key '{license_key}' was not added to License Manager"
+    )
+    assert ret["result"] == False
 
 
 def test_list(patch_salt_globals, license_key, vmware_license_mgr_inst):
@@ -35,10 +46,12 @@ def test_list(patch_salt_globals, license_key, vmware_license_mgr_inst):
     Test scenarios for list licenses on vCenter
     """
     # List the vCenter licenses.
-    licenses = license_mgr_mod.list_(service_instance=vmware_license_mgr_inst)
+    ret = license_mgr_mod.list_(service_instance=vmware_license_mgr_inst)
 
-    ## TBD need real licenses to play with first
-    ## assert license_key in licenses
+    # should have vCenter and ESXi at least
+    licenses = ret["licenses"]
+    assert type(licenses) == list
+    assert len(licenses) >= 2
 
 
 def test_remove(patch_salt_globals, license_key, vmware_license_mgr_inst):
@@ -48,9 +61,12 @@ def test_remove(patch_salt_globals, license_key, vmware_license_mgr_inst):
     kwargs = {}
     kwargs["service_instance"] = vmware_license_mgr_inst
 
-    # license_mgr.remove on an existing vCenter. No changes should be made.
+    # don't have real license to test with (exposure on public repo)
+    # hence using fake which should generate error
     ret = license_mgr_mod.remove(license_key, **kwargs)
 
-    ## TBD need real licenses to play with first
-    ## assert ret["changes"] == {vmware_license_mgr: True}
-    ## assert ret["result"] is True
+    assert (
+        ret["message"]
+        == f"Failed specified license key '{license_key}' was not found in License Manager"
+    )
+    assert ret["result"] == False

--- a/tests/integration/states/test_license_mgr.py
+++ b/tests/integration/states/test_license_mgr.py
@@ -27,7 +27,7 @@ def test_present(patch_salt_globals, license_key, vmware_license_mgr_inst):
 
     assert (
         ret["message"]
-        == f"Failed specified license key '{license_key}' was not added to License Manager"
+        == "Failed to add a license key due to Exception 'License is not valid for this product'"
     )
     assert ret["result"] == False
 
@@ -43,10 +43,7 @@ def test_absent(patch_salt_globals, license_key, vmware_license_mgr_inst):
     # hence using fake which should generate error
     ret = license_mgr_st.absent(license_key, **kwargs)
 
-    assert (
-        ret["message"]
-        == f"Failed specified license key '{license_key}' was not found in License Manager"
-    )
+    assert ret["message"] == "Failed specified license key was not found in License Manager"
     assert ret["result"] == False
 
 
@@ -64,7 +61,7 @@ def test_present_dry_run(patch_salt_globals, license_key, vmware_license_mgr_ins
 
     assert (
         ret["message"]
-        == f"Failed specified license key '{license_key}' was not added to License Manager"
+        == "Failed to add a license key due to Exception 'License is not valid for this product'"
     )
     assert ret["result"] == False
 
@@ -80,8 +77,5 @@ def test_absent_dry_run(patch_salt_globals, license_key, vmware_license_mgr_inst
     # hence using fake which should generate error
     ret = license_mgr_st.absent(license_key, **kwargs)
 
-    assert (
-        ret["message"]
-        == f"Failed specified license key '{license_key}' was not found in License Manager"
-    )
+    assert ret["message"] == "Failed specified license key was not found in License Manager"
     assert ret["result"] == False

--- a/tests/integration/states/test_license_mgr.py
+++ b/tests/integration/states/test_license_mgr.py
@@ -1,0 +1,67 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+import uuid
+
+import pytest
+import saltext.vmware.modules.license_mgr as license_mgr_mod
+
+
+@pytest.fixture
+def dry_run():
+    setattr(license_mgr_st, "__opts__", {"test": True})
+    yield
+    setattr(license_mgr_st, "__opts__", {"test": False})
+
+
+def test_present(license_key):
+    """
+    Test scenarios for license_mgr.present state run with existing license key it should have
+    """
+    # TBD Need to get service_instance
+    ## license_mgr = vmware_license_mgr
+
+    # license_mgr.present on an existing vCenter. No changes should be made.
+    ret = license_mgr_st.present(license_key)
+    assert ret["changes"] == {}
+    assert "already present. No changes made." in ret["comment"]
+    assert ret["result"] is True
+
+
+def test_absent(license_key):
+    """
+    Test scenarios for license_mgr.absent state run.
+    """
+    # TBD Need to get service_instance
+    ## license_mgr = vmware_license_mgr
+
+    # license_mgr.absent on an existing vCenter. No changes should be made.
+    ret = license_mgr_st.absent(license_key)
+    assert ret["changes"] == {vmware_license_mgr: True}
+    assert ret["result"] is True
+
+
+def test_present_dry_run(license_key, dry_run):
+    """
+    Test scenarios for license_mgr.present state run with existing license key it should have with test=True
+    """
+    # TBD Need to get service_instance
+    ## license_mgr = vmware_license_mgr
+
+    # license_mgr.present on an existing vCenter. No changes should be made.
+    ret = license_mgr_st.present(license_key)
+    assert ret["changes"] == {}
+    assert "already present. No changes made." in ret["comment"]
+    assert ret["result"] is True
+
+
+def test_absent_dry_run(license_key, dry_run):
+    """
+    Test scenarios for license_mgr.absent state run with test=True.
+    """
+    # TBD Need to get service_instance
+    ## license_mgr = vmware_license_mgr
+
+    # license_mgr.absent on an existing vCenter. No changes should be made.
+    ret = license_mgr_st.absent(license_key)
+    assert ret["changes"] == {vmware_license_mgr: True}
+    assert ret["result"] is True

--- a/tests/integration/states/test_license_mgr.py
+++ b/tests/integration/states/test_license_mgr.py
@@ -3,7 +3,7 @@
 import uuid
 
 import pytest
-import saltext.vmware.modules.license_mgr as license_mgr_mod
+import saltext.vmware.states.license_mgr as license_mgr_st
 
 
 @pytest.fixture
@@ -13,55 +13,75 @@ def dry_run():
     setattr(license_mgr_st, "__opts__", {"test": False})
 
 
-def test_present(license_key):
+def test_present(patch_salt_globals, license_key, vmware_license_mgr_inst):
     """
     Test scenarios for license_mgr.present state run with existing license key it should have
     """
-    # TBD Need to get service_instance
-    ## license_mgr = vmware_license_mgr
+    kwargs = {}
+    kwargs["service_instance"] = vmware_license_mgr_inst
 
     # license_mgr.present on an existing vCenter. No changes should be made.
-    ret = license_mgr_st.present(license_key)
-    assert ret["changes"] == {}
-    assert "already present. No changes made." in ret["comment"]
-    assert ret["result"] is True
+    # don't have real license to test with (exposure on public repo)
+    # hence using fake which should generate error
+    ret = license_mgr_st.present(license_key, **kwargs)
+
+    assert (
+        ret["message"]
+        == f"Failed specified license key '{license_key}' was not added to License Manager"
+    )
+    assert ret["result"] == False
 
 
-def test_absent(license_key):
+def test_absent(patch_salt_globals, license_key, vmware_license_mgr_inst):
     """
     Test scenarios for license_mgr.absent state run.
     """
-    # TBD Need to get service_instance
-    ## license_mgr = vmware_license_mgr
+    kwargs = {}
+    kwargs["service_instance"] = vmware_license_mgr_inst
 
-    # license_mgr.absent on an existing vCenter. No changes should be made.
-    ret = license_mgr_st.absent(license_key)
-    assert ret["changes"] == {vmware_license_mgr: True}
-    assert ret["result"] is True
+    # don't have real license to test with (exposure on public repo)
+    # hence using fake which should generate error
+    ret = license_mgr_st.absent(license_key, **kwargs)
+
+    assert (
+        ret["message"]
+        == f"Failed specified license key '{license_key}' was not found in License Manager"
+    )
+    assert ret["result"] == False
 
 
-def test_present_dry_run(license_key, dry_run):
+def test_present_dry_run(patch_salt_globals, license_key, vmware_license_mgr_inst, dry_run):
     """
     Test scenarios for license_mgr.present state run with existing license key it should have with test=True
     """
-    # TBD Need to get service_instance
-    ## license_mgr = vmware_license_mgr
+    kwargs = {}
+    kwargs["service_instance"] = vmware_license_mgr_inst
 
     # license_mgr.present on an existing vCenter. No changes should be made.
-    ret = license_mgr_st.present(license_key)
-    assert ret["changes"] == {}
-    assert "already present. No changes made." in ret["comment"]
-    assert ret["result"] is True
+    # don't have real license to test with (exposure on public repo)
+    # hence using fake which should generate error
+    ret = license_mgr_st.present(license_key, **kwargs)
+
+    assert (
+        ret["message"]
+        == f"Failed specified license key '{license_key}' was not added to License Manager"
+    )
+    assert ret["result"] == False
 
 
-def test_absent_dry_run(license_key, dry_run):
+def test_absent_dry_run(patch_salt_globals, license_key, vmware_license_mgr_inst, dry_run):
     """
     Test scenarios for license_mgr.absent state run with test=True.
     """
-    # TBD Need to get service_instance
-    ## license_mgr = vmware_license_mgr
+    kwargs = {}
+    kwargs["service_instance"] = vmware_license_mgr_inst
 
-    # license_mgr.absent on an existing vCenter. No changes should be made.
-    ret = license_mgr_st.absent(license_key)
-    assert ret["changes"] == {vmware_license_mgr: True}
-    assert ret["result"] is True
+    # don't have real license to test with (exposure on public repo)
+    # hence using fake which should generate error
+    ret = license_mgr_st.absent(license_key, **kwargs)
+
+    assert (
+        ret["message"]
+        == f"Failed specified license key '{license_key}' was not found in License Manager"
+    )
+    assert ret["result"] == False


### PR DESCRIPTION
Add support in VMware salt extension to add, remove and list license keys for vCenter, ESXi Hosts, datacenters and clusters.

Satisfies https://jira.eng.vmware.com/browse/VRAE-3249

Note this duplicates similar functionality provided by Ansible (v2.9), however during development it was noted that Ansible functional support does not allow for all possible error handling.  This version of code contains better error  handling on addition and removal of licenses.

Tests have been written, but unable to provide crippled licenses which could be used in a public code base, hence using fake licenses as part of testing.  However, hand unit-testing with valid license keys has been performed before submitting the PR without issue.
