### PR TITLE
Fix several tests

### DIFF
--- a/src/saltext/vmware/modules/cluster_drs.py
+++ b/src/saltext/vmware/modules/cluster_drs.py
@@ -20,7 +20,6 @@ except ImportError:
 
 __virtualname__ = "vmware_cluster_drs"
 __proxyenabled__ = ["vmware_cluster_drs"]
-__func_alias__ = {"get_": "get"}
 
 
 def __virtual__():

--- a/src/saltext/vmware/modules/datacenter.py
+++ b/src/saltext/vmware/modules/datacenter.py
@@ -19,7 +19,7 @@ except ImportError:
 
 __virtualname__ = "vmware_datacenter"
 __proxyenabled__ = ["vmware_datacenter"]
-__func_alias__ = {"list_": "list", "get_": "get"}
+__func_alias__ = {"list_": "list"}
 
 
 def __virtual__():
@@ -63,7 +63,7 @@ def create(name, service_instance=None):
     return {name: True}
 
 
-def get_(name, service_instance=None):
+def get(name, service_instance=None):
     """
     Get the properties of a datacenter.
 

--- a/tests/integration/modules/test_cluster.py
+++ b/tests/integration/modules/test_cluster.py
@@ -1,7 +1,6 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import uuid
-from unittest.mock import patch
 
 import pytest
 import saltext.vmware.modules.cluster as cluster

--- a/tests/integration/modules/test_datacenter.py
+++ b/tests/integration/modules/test_datacenter.py
@@ -1,7 +1,6 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import uuid
-from unittest.mock import patch
 
 import saltext.vmware.modules.datacenter as datacenter
 
@@ -13,12 +12,12 @@ def test_get(vmware_datacenter, service_instance):
 
     # Get a non existent datacenter. Should return False
     dc1_name = str(uuid.uuid4())
-    dc1 = datacenter.get(cluster_name=dc1_name, service_instance=service_instance)
+    dc1 = datacenter.get(name=dc1_name, service_instance=service_instance)
     assert dc1[dc1_name] is False
     assert "reason" in dc1
 
     # Now get the created datacenter. Should return all properties of DC.
-    dc1 = datacenter.get(cluster_name=vmware_datacenter, service_instance=service_instance)
+    dc1 = datacenter.get(name=vmware_datacenter, service_instance=service_instance)
     assert dc1["name"] == vmware_datacenter
 
 

--- a/tests/integration/modules/test_datastore.py
+++ b/tests/integration/modules/test_datastore.py
@@ -4,23 +4,28 @@ import pytest
 from saltext.vmware.modules import datastore
 
 
-def test_maintenance_mode(integration_test_config, patch_salt_globals_datastore):
+@pytest.fixture
+def datastores(integration_test_config):
+    return integration_test_config.get("datastores", [])
+
+
+def test_maintenance_mode(datastores, patch_salt_globals_datastore):
     """
     Test datastore maintenance mode
     """
-    if integration_test_config["datastores"]:
-        res = datastore.maintenance_mode(integration_test_config["datastores"][0])
+    if datastores:
+        res = datastore.maintenance_mode(datastores[0])
         assert res["maintenanceMode"] == "inMaintenance"
     else:
         pytest.skip("test requires at least one datastore")
 
 
-def test_exit_maintenance_mode(integration_test_config, patch_salt_globals_datastore):
+def test_exit_maintenance_mode(datastores, patch_salt_globals_datastore):
     """
     Test datastore exit maintenance mode
     """
-    if integration_test_config["datastores"]:
-        res = datastore.exit_maintenance_mode(integration_test_config["datastores"][0])
+    if datastores:
+        res = datastore.exit_maintenance_mode(datastores[0])
         assert res["maintenanceMode"] == "normal"
     else:
         pytest.skip("test requires at least one datastore")

--- a/tests/integration/modules/test_license_mgr.py
+++ b/tests/integration/modules/test_license_mgr.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import uuid
-from unittest.mock import patch
 
 import pytest
 import saltext.vmware.modules.license_mgr as license_mgr_mod

--- a/tests/integration/states/test_esxi.py
+++ b/tests/integration/states/test_esxi.py
@@ -1,7 +1,8 @@
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 import uuid
-from unittest.mock import MagicMock
+from unittest.mock import create_autospec
+from unittest.mock import patch
 
 import pytest
 import salt
@@ -18,23 +19,44 @@ def dry_run():
 
 @pytest.fixture
 def user_add_error():
-    esxi.__salt__["vmware_esxi.add_user"] = MagicMock(
-        side_effect=salt.exceptions.SaltException("add error")
-    )
+    # TODO: patch tests should be unit, not integration -W. Werner, 2022-02-09
+    with patch.dict(
+        esxi.__salt__,
+        {
+            "vmware_esxi.add_user": create_autospec(
+                esxi_mod.add_user, side_effect=salt.exceptions.SaltException("add error")
+            )
+        },
+    ):
+        yield
 
 
 @pytest.fixture
 def user_update_error():
-    esxi.__salt__["vmware_esxi.update_user"] = MagicMock(
-        side_effect=salt.exceptions.SaltException("update error")
-    )
+    # TODO: patch tests should be unit, not integration -W. Werner, 2022-02-09
+    with patch.dict(
+        esxi.__salt__,
+        {
+            "vmware_esxi.update_user": create_autospec(
+                esxi_mod.update_user, side_effect=salt.exceptions.SaltException("update error")
+            )
+        },
+    ):
+        yield
 
 
 @pytest.fixture
 def user_remove_error():
-    esxi.__salt__["vmware_esxi.remove_user"] = MagicMock(
-        side_effect=salt.exceptions.SaltException("remove error")
-    )
+    # TODO: patch tests should be unit, not integration -W. Werner, 2022-02-09
+    with patch.dict(
+        esxi.__salt__,
+        {
+            "vmware_esxi.remove_user": create_autospec(
+                esxi_mod.remove_user, side_effect=salt.exceptions.SaltException("remove error")
+            )
+        },
+    ):
+        yield
 
 
 def test_user_present_absent(patch_salt_globals):


### PR DESCRIPTION
There were a couple of places where we were using index access instead of
`.get` or `thing in dict`. This sorted at least several of those out. It also
fixes a bunch of incorrect patching.

We do have some patch code erroneously in the integration tests -- they should
be in the unit tests instead since they're just testing that if a certain error
response happens that an error is raised. There's no need to actually hit a
vCenter for that.

There may be some other integration tests still failing - opening this PR
before they're done running.
