### PR TITLE
[DOCS] Update dvswitch examples to correct module names. Fixes #260

### DIFF
--- a/src/saltext/vmware/modules/dvswitch.py
+++ b/src/saltext/vmware/modules/dvswitch.py
@@ -374,7 +374,7 @@ def add_hosts(
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.add_hosts switch_name=dvs1 host_name=host1 num_ports=256 mtu=1800
+        salt '*' vmware_dvswitch.add_hosts switch_name=dvs1 host_name=host1 num_ports=256 mtu=1800
 
     """
     log.debug("Running vmware_dvswitch.add_hosts")
@@ -459,7 +459,7 @@ def update_hosts(
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.update_hosts switch_name=dvs1 host_name=host1 num_ports=256 mtu=1800
+        salt '*' vmware_dvswitch.update_hosts switch_name=dvs1 host_name=host1 num_ports=256 mtu=1800
 
     """
     log.debug("Running vmware_dvswitch.update_hosts")


### PR DESCRIPTION
Fixes incorrect examples in the vmware_dvswitch module.

Fixes #260 