### PR TITLE
[DOCS] Update esxi docs with corrections and new examples

### DIFF
--- a/src/saltext/vmware/modules/esxi.py
+++ b/src/saltext/vmware/modules/esxi.py
@@ -2103,7 +2103,7 @@ def add(
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.add host=host01 root_user=root password=CorrectHorseBatteryStable cluster_name=cl1 datacenter_name=dc1 verify_host_cert=False connect=True
+        salt '*' vmware_esxi.add host=host01 root_user=root password=CorrectHorseBatteryStaple cluster_name=cl1 datacenter_name=dc1 verify_host_cert=False connect=True
     """
     log.debug(f"Adding ESXi instance {host}.")
     if service_instance is None:

--- a/src/saltext/vmware/modules/esxi.py
+++ b/src/saltext/vmware/modules/esxi.py
@@ -1982,6 +1982,10 @@ def connect(host, service_instance=None):
 
     service_instance
         The Service Instance from which to obtain managed object references. (Optional)
+
+    .. code-block:: bash
+
+        salt '*' vmware_esxi.connect host=host01
     """
     log.debug(f"Connect ESXi instance {host}.")
     if service_instance is None:
@@ -2000,6 +2004,10 @@ def disconnect(host, service_instance=None):
 
     service_instance
         The Service Instance from which to obtain managed object references. (Optional)
+    
+    .. code-block:: bash
+
+        salt '*' vmware_esxi.disconnect host=host01
     """
     log.debug(f"Disconnect ESXi instance {host}.")
     if service_instance is None:
@@ -2018,6 +2026,10 @@ def remove(host, service_instance=None):
 
     service_instance
         The Service Instance from which to obtain managed object references. (Optional)
+    
+    .. code-block:: bash
+
+        salt '*' vmware_esxi.remove host=host01
     """
     log.debug(f"Remove ESXi instance {host}.")
     if service_instance is None:
@@ -2039,6 +2051,10 @@ def move(host, cluster_name, service_instance=None):
 
     service_instance
         The Service Instance from which to obtain managed object references. (Optional)
+    
+    .. code-block:: bash
+
+        salt '*' vmware_esxi.move host=host01 cluster=cl1
     """
     log.debug(f"Move ESXi instance {host}.")
     if service_instance is None:
@@ -2073,7 +2089,7 @@ def add(
     cluster_name
         Name of cluster ESXi host is being added to.
 
-    datacenter
+    datacenter_name
         Datacenter that contains cluster that ESXi instance is being added to.
 
     verify_host_cert
@@ -2084,6 +2100,10 @@ def add(
 
     service_instance
         The Service Instance from which to obtain managed object references. (Optional)
+
+    .. code-block:: bash
+
+        salt '*' vmware_esxi.add host=host01 root_user=root password=CorrectHorseBatteryStable cluster_name=cl1 datacenter_name=dc1 verify_host_cert=False connect=True
     """
     log.debug(f"Adding ESXi instance {host}.")
     if service_instance is None:
@@ -2302,7 +2322,7 @@ def in_maintenance_mode(host, service_instance=None):
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.in_maintenance_mode '10.288.6.117'
+        salt '*' vmware_esxi.in_maintenance_mode '192.0.2.117'
     """
     if isinstance(host, vim.HostSystem):
         host_ref = host
@@ -2349,7 +2369,7 @@ def maintenance_mode(
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.maintenance_mode '10.288.6.117'
+        salt '*' vmware_esxi.maintenance_mode '192.0.2.117'
     """
     if isinstance(host, vim.HostSystem):
         host_ref = host
@@ -2392,7 +2412,7 @@ def exit_maintenance_mode(host, timeout=0, catch_task_error=True, service_instan
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.exit_maintenance_mode '10.288.6.117'
+        salt '*' vmware_esxi.exit_maintenance_mode '192.0.2.117'
     """
     if isinstance(host, vim.HostSystem):
         host_ref = host
@@ -2427,7 +2447,7 @@ def in_lockdown_mode(host, service_instance=None):
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.in_lockdown_mode '10.288.6.117'
+        salt '*' vmware_esxi.in_lockdown_mode '192.0.2.117'
     """
     if isinstance(host, vim.HostSystem):
         host_ref = host
@@ -2456,7 +2476,7 @@ def lockdown_mode(host, catch_task_error=True, service_instance=None):
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.lockdown_mode '10.288.6.117'
+        salt '*' vmware_esxi.lockdown_mode '192.0.2.117'
     """
     if isinstance(host, vim.HostSystem):
         host_ref = host
@@ -2493,7 +2513,7 @@ def exit_lockdown_mode(host, catch_task_error=True, service_instance=None):
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.exit_lockdown_mode '10.288.6.117'
+        salt '*' vmware_esxi.exit_lockdown_mode '192.0.2.117'
     """
     if isinstance(host, vim.HostSystem):
         host_ref = host

--- a/src/saltext/vmware/modules/esxi.py
+++ b/src/saltext/vmware/modules/esxi.py
@@ -2004,7 +2004,7 @@ def disconnect(host, service_instance=None):
 
     service_instance
         The Service Instance from which to obtain managed object references. (Optional)
-    
+
     .. code-block:: bash
 
         salt '*' vmware_esxi.disconnect host=host01
@@ -2026,7 +2026,7 @@ def remove(host, service_instance=None):
 
     service_instance
         The Service Instance from which to obtain managed object references. (Optional)
-    
+
     .. code-block:: bash
 
         salt '*' vmware_esxi.remove host=host01
@@ -2051,7 +2051,7 @@ def move(host, cluster_name, service_instance=None):
 
     service_instance
         The Service Instance from which to obtain managed object references. (Optional)
-    
+
     .. code-block:: bash
 
         salt '*' vmware_esxi.move host=host01 cluster=cl1

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -238,7 +238,7 @@ def vmkernel_adapter_present(
 
     .. code-block:: yaml
 
-    Save Adapter:
+      # Save Adapter:
       vmware_esxi.vmkernel_adapter_present:
         - name: vmk1
         - port_group_name: portgroup1
@@ -359,7 +359,7 @@ def vmkernel_adapter_absent(
 
     .. code-block:: yaml
 
-    Delete Adapter:
+      # Delete Adapter:
       vmware_esxi.vmkernel_adapter_absent:
         - name: vmk1
     """
@@ -453,7 +453,7 @@ def user_present(
 
     .. code-block:: yaml
 
-    Create User:
+      # Create User:
       vmware_esxi.user_present:
         - name: local_user
         - password: secret
@@ -585,7 +585,7 @@ def user_absent(
 
     .. code-block:: yaml
 
-    Remove User:
+      # Remove User:
       vmware_esxi.user_absent:
         - name: local_user
 
@@ -692,7 +692,7 @@ def maintenance_mode(
         salt '*' vmware_esxi.maintenance_mode '10.288.6.117'
     .. code-block:: yaml
 
-        Maintenance Mode:
+          # Maintenance Mode:
           vmware_esxi.maintenance_mode:
             - host: '10.288.6.117'
             - enter_maintenance_mode: true
@@ -781,7 +781,7 @@ def lockdown_mode(
         salt '*' vmware_esxi.lockdown_mode '10.288.6.117'
     .. code-block:: yaml
 
-        Lockdown Mode:
+          # Lockdown Mode:
           vmware_esxi.lockdown_mode:
             - host: '10.288.6.117'
             - enter_lockdown_mode: true

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -238,11 +238,11 @@ def vmkernel_adapter_present(
 
     .. code-block:: yaml
 
-      # Save Adapter:
-      vmware_esxi.vmkernel_adapter_present:
-        - name: vmk1
-        - port_group_name: portgroup1
-        - dvsswitch_name: vswitch1
+        Save Adapter:
+          vmware_esxi.vmkernel_adapter_present:
+            - name: vmk1
+            - port_group_name: portgroup1
+            - dvsswitch_name: vswitch1
     """
     log.debug("Running vmware_esxi.vmkernel_adapter_present")
     ret = {"name": name, "result": None, "comment": "", "changes": {}}
@@ -359,9 +359,9 @@ def vmkernel_adapter_absent(
 
     .. code-block:: yaml
 
-      # Delete Adapter:
-      vmware_esxi.vmkernel_adapter_absent:
-        - name: vmk1
+        Delete Adapter:
+          vmware_esxi.vmkernel_adapter_absent:
+            - name: vmk1
     """
     log.debug("Running vmware_esxi.vmkernel_adapter_absent")
     ret = {"name": name, "result": None, "comment": "", "changes": {}}
@@ -453,10 +453,10 @@ def user_present(
 
     .. code-block:: yaml
 
-      # Create User:
-      vmware_esxi.user_present:
-        - name: local_user
-        - password: secret
+        Create User:
+          vmware_esxi.user_present:
+            - name: local_user
+            - password: secret
 
     """
     log.debug("Running vmware_esxi.user_present")
@@ -585,9 +585,9 @@ def user_absent(
 
     .. code-block:: yaml
 
-      # Remove User:
-      vmware_esxi.user_absent:
-        - name: local_user
+        Remove User:
+          vmware_esxi.user_absent:
+            - name: local_user
 
     """
     log.debug("Running vmware_esxi.user_absent")
@@ -689,12 +689,12 @@ def maintenance_mode(
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.maintenance_mode '10.288.6.117'
+        salt '*' vmware_esxi.maintenance_mode '2001:db8:6::117'
     .. code-block:: yaml
 
-          # Maintenance Mode:
+        Maintenance Mode:
           vmware_esxi.maintenance_mode:
-            - host: '10.288.6.117'
+            - host: '2001:db8:6::117'
             - enter_maintenance_mode: true
     """
     ret = {"name": name, "changes": {}, "result": True, "comment": ""}
@@ -778,12 +778,12 @@ def lockdown_mode(
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.lockdown_mode '10.288.6.117'
+        salt '*' vmware_esxi.lockdown_mode '2001:db8:6::117'
     .. code-block:: yaml
 
-          # Lockdown Mode:
+        Lockdown Mode:
           vmware_esxi.lockdown_mode:
-            - host: '10.288.6.117'
+            - host: '2001:db8:6::117'
             - enter_lockdown_mode: true
     """
     ret = {"name": name, "changes": {}, "result": True, "comment": ""}

--- a/src/saltext/vmware/states/esxi.py
+++ b/src/saltext/vmware/states/esxi.py
@@ -221,7 +221,7 @@ def vmkernel_adapter_present(
     network_subnet_mask
         Static netmask required. Required if type = 'static'.
 
-    network_tcpip_stack
+    network_tcp_ip_stack
         The TCP/IP stack for the VMKernel interface. Valid values: "default", "provisioning", "vmotion", "vxlan".
 
     datacenter_name
@@ -689,12 +689,12 @@ def maintenance_mode(
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.maintenance_mode '2001:db8:6::117'
+        salt '*' vmware_esxi.maintenance_mode '192.0.2.117'
     .. code-block:: yaml
 
         Maintenance Mode:
           vmware_esxi.maintenance_mode:
-            - host: '2001:db8:6::117'
+            - host: '192.0.2.117'
             - enter_maintenance_mode: true
     """
     ret = {"name": name, "changes": {}, "result": True, "comment": ""}
@@ -778,12 +778,12 @@ def lockdown_mode(
 
     .. code-block:: bash
 
-        salt '*' vmware_esxi.lockdown_mode '2001:db8:6::117'
+        salt '*' vmware_esxi.lockdown_mode '192.0.2.117'
     .. code-block:: yaml
 
         Lockdown Mode:
           vmware_esxi.lockdown_mode:
-            - host: '2001:db8:6::117'
+            - host: '192.0.2.117'
             - enter_lockdown_mode: true
     """
     ret = {"name": name, "changes": {}, "result": True, "comment": ""}


### PR DESCRIPTION
Docs cleans up for `saltext.vmware.modules.esxi` and `saltext.vmware.states.esxi`:

- Use example host IP addresses that are both valid and from the RFC5737 documentation range
- Correct use of `datacenter_name` in `saltext.vmware.modules.esxi.add`
- Add examples for `saltext.vmware.modules.esxi.connect`, `saltext.vmware.modules.esxi.disconnect`, `saltext.vmware.modules.esxi.remove`, `saltext.vmware.modules.esxi.move`, `saltext.vmware.modules.esxi.add`
- Correct use of `network_tcp_ip_stack` in `saltext.vmware.states.esxi.vmkernel_adapter_present`
- Fix examples for `saltext.vmware.states.esxi.vmkernel_adapter_present`. `saltext.vmware.states.esxi.vmkernel_adapter_absent`, `saltext.vmware.states.esxi.user_present`, `saltext.vmware.states.esxi.user_absent`, `saltext.vmware.states.esxi.maintenance_mode`, `saltext.vmware.states.esxi.lockdown_mode`