### PR TITLE
[DOCS] Fix examples in `license_mgr` execution modules

### DIFF
--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -51,7 +51,7 @@ def add(license_key, **kwargs):
 
     CLI Example:
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt '*' vmware_license_mgr.add license_key datacenter_name=dc1
     """
@@ -139,7 +139,7 @@ def remove(license_key, **kwargs):
 
     CLI Example:
 
-    .. code-block: bash
+    .. code-block:: bash
 
         salt '*' vmware_license_mgr.remove license_key
     """

--- a/src/saltext/vmware/modules/license_mgr.py
+++ b/src/saltext/vmware/modules/license_mgr.py
@@ -53,7 +53,7 @@ def add(license_key, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' vmware_license_mgr.add license_key datacenter_name=dc1
+        salt '*' vmware_license_mgr.add license_key=AAAAA-11111-AAAAA-11111-AAAAA datacenter_name=dc1
     """
     ret = {}
 
@@ -141,7 +141,7 @@ def remove(license_key, **kwargs):
 
     .. code-block:: bash
 
-        salt '*' vmware_license_mgr.remove license_key
+        salt '*' vmware_license_mgr.remove license_key=AAAAA-11111-AAAAA-11111-AAAAA
     """
     ret = {}
 


### PR DESCRIPTION
- Add missing colons to code-block tags that prevent them from displaying correctly.