### PR TITLE
scraper: fix 'help' message's English syntax

### DIFF
--- a/tools/test_value_scraper_vmc.py
+++ b/tools/test_value_scraper_vmc.py
@@ -235,7 +235,7 @@ if __name__ == "__main__":
         dest="create",
         action="store_true",
         default=None,
-        help="Create config file if not exists.",
+        help="Create config file if it does not exist.",
     )
     parser.add_argument(
         "CONFIG_FILE",


### PR DESCRIPTION
Fix the English of help message, but mostly verify I can contribute to this repo.