### PR TITLE
Change docstrings from private addresses to documentation addresses

### DIFF
--- a/src/saltext/vmware/modules/esxi.py
+++ b/src/saltext/vmware/modules/esxi.py
@@ -935,7 +935,7 @@ def backup_config(
 
     .. code-block:: bash
 
-        salt * vmware_esxi.backup_config host_name=10.225.0.53 http_opts='{"verify_ssl": False}'
+        salt * vmware_esxi.backup_config host_name=203.0.113.53 http_opts='{"verify_ssl": False}'
     """
     log.debug("Running vmware_esxi.backup_config")
     ret = {}
@@ -986,7 +986,7 @@ def restore_config(
         Specify the source file from which the configuration is to be restored.
         The file can be either on the master, locally on the minion or url.
         E.g.: salt://vmware_config.tgz, /tmp/minion1/vmware_config.tgz or
-        10.225.0.53/downloads/5220da48-552e-5779-703e-5705367bd6d6/configBundle-ESXi-190313806785.eng.vmware.com.tgz
+        203.0.113.53/downloads/5220da48-552e-5779-703e-5705367bd6d6/configBundle-ESXi-190313806785.eng.vmware.com.tgz
 
     saltenv
         Specify the saltenv when the source file needs to be retireved from the master. (optional)

--- a/src/saltext/vmware/modules/nsxt_policy_segment.py
+++ b/src/saltext/vmware/modules/nsxt_policy_segment.py
@@ -683,7 +683,8 @@ def create_or_update(
                              value is assigned to DHCP server IP address.
                              Existing values cannot be deleted or modified, but
                              additional DHCP ranges can be added.
-                             Formats, e.g. 10.12.2.64/26, 10.12.2.2-10.12.2.50
+                             Formats, e.g. 203.0.113.64/26,
+                             203.0.113.2-203.0.113.50
 
                 type: list
             gateway_address:

--- a/src/saltext/vmware/modules/nsxt_transport_node.py
+++ b/src/saltext/vmware/modules/nsxt_transport_node.py
@@ -475,7 +475,7 @@ def create(
              node_deployment_info:
                resource_type: "HostNode"
                display_name: "Host_1"
-               ip_addresses: ["10.149.55.21"]
+               ip addresses: ["203.0.113.21"]
                os_type: "ESXI"
                os_version: "6.5.0"
                host_credential:
@@ -853,7 +853,7 @@ def update(
 
                resource_type: "HostNode"
                display_name: "Host_1"
-               ip_addresses: ["10.149.55.21"]
+               ip_addresses: ["203.0.113.21"]
                os_type: "ESXI"
                os_version: "6.5.0"
                host_credential:

--- a/src/saltext/vmware/modules/vmc_dhcp_profiles.py
+++ b/src/saltext/vmware/modules/vmc_dhcp_profiles.py
@@ -386,7 +386,7 @@ def create(
             dhcp-server-profiles:
             {
                 "server_addresses": [
-                    "10.22.12.2/23"
+                    "203.0.113.2/23"
                 ],
                 "tags": [
                     {
@@ -400,7 +400,7 @@ def create(
             dhcp-relay-profiles:
             {
                 "server_addresses": [
-                    "10.1.1.1"
+                    "203.0.113.1"
                 ],
                 "tags": [
                     {
@@ -545,7 +545,7 @@ def update(
             {
                 "display_name": "dhcp-test",
                 "server_addresses": [
-                    "10.22.12.2/23"
+                    "203.0.113.2/23"
                 ],
                 "tags": [
                     {
@@ -560,7 +560,7 @@ def update(
             {
                 "display_name": "dhcp-test",
                 "server_addresses": [
-                    "10.1.1.1"
+                    "203.0.113.1"
                 ],
                 "tags": [
                     {

--- a/src/saltext/vmware/modules/vmc_nat_rules.py
+++ b/src/saltext/vmware/modules/vmc_nat_rules.py
@@ -449,10 +449,10 @@ def create(
 
             {
                 "action": "REFLEXIVE",
-                "translated_network": "10.182.171.36",
+                "translated_network": "203.0.113.36",
                 "translated_ports": null,
                 "destination_network": "",
-                "source_network": "192.168.1.23",
+                "source_network": "198.51.100.23",
                 "sequence_number": 0,
                 "service": "",
                 "logging": false,
@@ -689,10 +689,10 @@ def update(
 
             {
                 "action": "REFLEXIVE",
-                "translated_network": "10.182.171.36",
+                "translated_network": "203.0.113.36",
                 "translated_ports": null,
                 "destination_network": "",
-                "source_network": "192.168.1.23",
+                "source_network": "198.51.100.23",
                 "sequence_number": 0,
                 "service": "",
                 "logging": false,

--- a/src/saltext/vmware/modules/vmc_networks.py
+++ b/src/saltext/vmware/modules/vmc_networks.py
@@ -350,14 +350,14 @@ def create(
                     {
                         "gateway_address": "100.1.1.1/16",
                         "dhcp_ranges": [
-                            "10.22.12.2/24"
+                            "203.0.113.2/24"
                         ],
                         "dhcp_config": {
                             "resource_type": "SegmentDhcpV4Config",
                             "lease_time": "8000",
                             "server_address": "100.1.0.0/16",
                             "dns_servers": [
-                                "10.22.12.0"
+                                "203.0.113.0"
                             ]
                         }
                     }
@@ -608,14 +608,14 @@ def update(
                     {
                         "gateway_address": "100.1.1.1/16",
                         "dhcp_ranges": [
-                            "10.22.12.2/24"
+                            "203.0.113.2/24"
                         ],
                         "dhcp_config": {
                             "resource_type": "SegmentDhcpV4Config",
                             "lease_time": "8000",
                             "server_address": "100.1.0.0/16",
                             "dns_servers": [
-                                "10.22.12.0"
+                                "203.0.113.0"
                             ]
                         }
                     }

--- a/src/saltext/vmware/modules/vmc_security_groups.py
+++ b/src/saltext/vmware/modules/vmc_security_groups.py
@@ -356,7 +356,7 @@ def create(
                {"member_type":"VirtualMachine","resource_type":"ExternalIDExpression",
                "external_ids":["52bf8bd0-95b1-2e58-5180-ccfa743da576"]}]
 
-            3. [{"ip_addresses" : ["10.2.23.1", "10.2.23.2"],
+            3. [{"ip_addresses" : ["203.0.113.1", "203.0.113.2"],
                   "resource_type" : "IPAddressExpression"} ]
 
             default value is []
@@ -519,7 +519,7 @@ def update(
                {"member_type":"VirtualMachine","resource_type":"ExternalIDExpression",
                "external_ids":["52bf8bd0-95b1-2e58-5180-ccfa743da576"]}]
 
-            3. [{ip_addresses" : ["10.2.23.1", "10.2.23.2"],
+            3. [{ip_addresses" : ["203.0.113.1", "203.0.113.2"],
                   "resource_type" : "IPAddressExpression"} ]
 
             default value is []

--- a/src/saltext/vmware/states/nsxt_license.py
+++ b/src/saltext/vmware/states/nsxt_license.py
@@ -13,7 +13,7 @@ Example usage :
 
     Ensure license exists:
         nsxt_license.present:
-            hostname: 10.11.12.13
+            hostname: 203.0.113.13
             username: admin
             password: admin_password
             license_key: ABCDE-12345-ABCDE-12345-ABCDE

--- a/src/saltext/vmware/states/nsxt_policy_segment.py
+++ b/src/saltext/vmware/states/nsxt_policy_segment.py
@@ -106,7 +106,7 @@ def present(
                   key: key
                   value: value
             ignored_address_bindings:
-              - ip_address: "10.1.2.122"
+              - ip_address: "203.0.113.122"
           - display_name: test-sp-2
             state: present
           - display_name: test-sp-3
@@ -429,7 +429,8 @@ def present(
                              value is assigned to DHCP server IP address.
                              Existing values cannot be deleted or modified, but
                              additional DHCP ranges can be added.
-                             Formats, e.g. 10.12.2.64/26, 10.12.2.2-10.12.2.50
+                             Formats, e.g. 203.0.113.64/26,
+                             203.0.113.2-203.0.113.50
 
                 type: list
             gateway_address:

--- a/src/saltext/vmware/states/nsxt_policy_tier0.py
+++ b/src/saltext/vmware/states/nsxt_policy_tier0.py
@@ -75,7 +75,7 @@ def present(
           internal_transit_subnets: ["1.2.0.0/24"]
           transit_subnets: ["100.64.0.0/16"]
           failover_mode: PREEMPTIVE
-          rd_admin_field: "10.10.10.10"
+          rd_admin_field: "203.0.113.10"
           dhcp_config_id: "DHCP-Relay"
           arp_limit: 5000
           force_whitelisting: False
@@ -92,13 +92,13 @@ def present(
             -  display_name: sr-1
                description: Created_by_API
                enabled_on_secondary: true
-               network: 10.10.10.0/23
+               network: 203.0.113.0/23
                next_hops:
                  -  admin_distance: 4
-                    ip_address: 10.1.2.3
+                    ip_address: 203.0.113.3
           bfd_peers:
             -  display_name: srbfdp-1
-               peer_address: 10.1.1.2
+               peer_address: 203.0.113.2
                bfd_profile_id: default
           locale_services:
             -  display_name: "test-t0ls"
@@ -118,7 +118,7 @@ def present(
                  timer:
                    restart_timer: 12
                  route_aggregations:
-                   - prefix: "10.1.1.0/24"
+                   - prefix: "203.0.113.0/24"
                    - prefix: "11.1.0.0/24"
                      summary_only: False
                  neighbors:

--- a/src/saltext/vmware/states/nsxt_transport_node.py
+++ b/src/saltext/vmware/states/nsxt_transport_node.py
@@ -42,7 +42,7 @@ Example:
 
                resource_type: "HostNode"
                display_name: "Host_1"
-               ip_addresses: ["10.149.55.21"]
+               ip_addresses: ["203.0.113.21"]
                os_type: "ESXI"
                os_version: "6.5.0"
                host_credential:
@@ -478,7 +478,7 @@ def present(
 
                resource_type: "HostNode"
                display_name: "Host_1"
-               ip_addresses: ["10.149.55.21"]
+               ip_addresses: ["203.0.113.21"]
                os_type: "ESXI"
                os_version: "6.5.0"
                host_credential:

--- a/src/saltext/vmware/states/vmc_dhcp_profiles.py
+++ b/src/saltext/vmware/states/vmc_dhcp_profiles.py
@@ -124,7 +124,7 @@ def present(
             for dhcp-server-profiles:
 
             server_addresses:
-              - 10.22.12.2/23
+              - 203.0.113.2/23
             tags:
               - tag: tag1
                 scope: scope1
@@ -133,7 +133,7 @@ def present(
             for dhcp-relay-profiles:
 
             server_addresses:
-              - 10.1.1.1
+              - 203.0.113.1
             tags:
               - tag: tag1
                 scope: scope1

--- a/src/saltext/vmware/states/vmc_nat_rules.py
+++ b/src/saltext/vmware/states/vmc_nat_rules.py
@@ -18,8 +18,8 @@ Example usage :
         - nat_rule: vCenter_Inbound_Rule_2
         - verify_ssl: False
         - cert: /path/to/client/certificate
-        - source_network: "10.117.5.73"
-        - translated_network: "192.168.1.1"
+        - source_network: "203.0.113.73"
+        - translated_network: "198.51.100.1"
 
 
 .. warning::
@@ -187,10 +187,10 @@ def present(
         .. code-block::
 
             action: REFLEXIVE
-            translated_network: 10.182.171.36
+            translated_network: 203.0.113.36
             translated_ports: null
             destination_network: ''
-            source_network: 192.168.1.23
+            source_network: 198.51.100.23
             sequence_number: 0
             service: ''
             logging: false

--- a/src/saltext/vmware/states/vmc_networks.py
+++ b/src/saltext/vmware/states/vmc_networks.py
@@ -128,13 +128,13 @@ def present(
                 subnets:
                   - gateway_address: 100.1.1.1/16
                     dhcp_ranges:
-                      - 10.22.12.2/24
+                      - 203.0.113.2/24
                     dhcp_config:
                       resource_type: SegmentDhcpV4Config
                       lease_time: '8000'
                       server_address: 100.1.0.0/16
                       dns_servers:
-                        - 10.22.12.0
+                        - 203.0.113.0
 
     admin_state
         (Optional) Represents Desired state of the Segment. Possible values: UP, DOWN

--- a/src/saltext/vmware/states/vmc_security_groups.py
+++ b/src/saltext/vmware/states/vmc_security_groups.py
@@ -107,7 +107,7 @@ def present(
                {"member_type":"VirtualMachine","resource_type":"ExternalIDExpression",
                "external_ids":["52bf8bd0-95b1-2e58-5180-ccfa743da576"]}]
 
-            3. [{"ip_addresses" : ["10.2.23.1", "10.2.23.2"],
+            3. [{"ip_addresses" : ["203.0.113.1", "203.0.113.2"],
                 "resource_type" : "IPAddressExpression"} ]
 
     description


### PR DESCRIPTION
Change RFC1918 private addresses to RFC5737 'TEST-NET-2' and 'TEST-NET-3' documentation addresses:
- 10.x.y.z --> 203.0.113.z
- 192.168.a.b --> 198.51.100.b