### PR TITLE
Fix bandit deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,6 +109,7 @@ repos:
         name: Run bandit against the code base
         args: [--silent, -lll, --skip, B701]
         exclude: src/saltext/vcenter/version.py
+        additional_dependencies: ['importlib_metadata<5']
   - repo: https://github.com/PyCQA/bandit
     rev: "1.7.0"
     hooks:
@@ -117,6 +118,7 @@ repos:
         name: Run bandit against the test suite
         args: [--silent, -lll, --skip, B701]
         files: ^tests/.*
+        additional_dependencies: ['importlib_metadata<5']
   # <---- Security -------------------------------------------------------------------------------
 
   # ----- Code Analysis ------------------------------------------------------------------------->


### PR DESCRIPTION
See https://github.com/PyCQA/bandit/issues/956 for specific info, but without adding the additional_dependencies, the plugins fail to load for bandit, oops!