### PR TITLE
Updates host get method to provide more info on the networking

### DIFF
--- a/src/saltext/vmware/modules/esxi.py
+++ b/src/saltext/vmware/modules/esxi.py
@@ -2577,13 +2577,68 @@ def get(
                 ret[h.name]["datastores"][store.name]["capacity"] = store.summary.capacity
                 ret[h.name]["datastores"][store.name]["free_space"] = store.summary.freeSpace
 
-            ret[h.name]["nics"] = {}
+            ret[h.name]["vnics"] = {}
             for nic in h.config.network.vnic:
-                ret[h.name]["nics"][nic.device] = {}
-                ret[h.name]["nics"][nic.device]["ip_address"] = nic.spec.ip.ipAddress
-                ret[h.name]["nics"][nic.device]["subnet_mask"] = nic.spec.ip.subnetMask
-                ret[h.name]["nics"][nic.device]["mac"] = nic.spec.mac
-                ret[h.name]["nics"][nic.device]["mtu"] = nic.spec.mtu
+                ret[h.name]["vnics"][nic.device] = {}
+                ret[h.name]["vnics"][nic.device]["ip_address"] = nic.spec.ip.ipAddress
+                ret[h.name]["vnics"][nic.device]["subnet_mask"] = nic.spec.ip.subnetMask
+                ret[h.name]["vnics"][nic.device]["mac"] = nic.spec.mac
+                ret[h.name]["vnics"][nic.device]["mtu"] = nic.spec.mtu
+                ret[h.name]["vnics"][nic.device]["portgroup"] = nic.spec.portgroup
+                if nic.spec.distributedVirtualPort:
+                    ret[h.name]["vnics"][nic.device][
+                        "distributed_virtual_portgroup"] = nic.spec.distributedVirtualPort.portgroupKey
+                    ret[h.name]["vnics"][nic.device]["distributed_virtual_switch"] = utils_vmware._get_dvs_by_uuid(
+                        service_instance, nic.spec.distributedVirtualPort.switchUuid).config.name
+                else:
+                    ret[h.name]["vnics"][nic.device]["distributed_virtual_portgroup"] = None
+                    ret[h.name]["vnics"][nic.device]["distributed_virtual_switch"] = None
+
+            ret[h.name]["pnics"] = {}
+            for nic in h.config.network.pnic:
+                ret[h.name]["pnics"][nic.device] = {}
+                ret[h.name]["pnics"][nic.device]["mac"] = nic.mac
+                if nic.linkSpeed:
+                    ret[h.name]["pnics"][nic.device]["speed"] = nic.linkSpeed.speedMb
+                else:
+                    ret[h.name]["pnics"][nic.device]["speed"] = -1
+
+                if not h.configManager.networkSystem.capabilities.supportsNetworkHints:
+                    continue
+
+                # Add CDP/LLDP information
+                # TODO: Add LLDP information
+                ret[h.name]["pnics"][nic.device]["cdp"] = {}
+                for hint in h.configManager.networkSystem.QueryNetworkHint(nic.device):
+                    csp = hint.connectedSwitchPort
+                    if csp:
+                        ret[h.name]["pnics"][nic.device]["cdp"]["switch_id"] = csp.devId
+                        ret[h.name]["pnics"][nic.device]["cdp"]["system_name"] = csp.systemName
+                        ret[h.name]["pnics"][nic.device]["cdp"]["platform"] = csp.hardwarePlatform
+                        ret[h.name]["pnics"][nic.device]["cdp"]["ip_address"] = csp.address
+                        ret[h.name]["pnics"][nic.device]["cdp"]["port_id"] = csp.portId
+                        ret[h.name]["pnics"][nic.device]["cdp"]["vlan"] = csp.vlan
+
+            ret[h.name]["vswitches"] = {}
+            for vswitch in h.config.network.vswitch:
+                ret[h.name]["vswitches"][vswitch.name] = {}
+                ret[h.name]["vswitches"][vswitch.name]["mtu"] = vswitch.mtu
+                ret[h.name]["vswitches"][vswitch.name]["pnics"] = []
+                ret[h.name]["vswitches"][vswitch.name]["portgroups"] = []
+                for pnic in vswitch.pnic:
+                    ret[h.name]["vswitches"][vswitch.name]["pnics"].append(
+                        pnic.replace("key-vim.host.PhysicalNic-", "")
+                    )
+                for pg in vswitch.portgroup:
+                    ret[h.name]["vswitches"][vswitch.name]["portgroups"].append(
+                        pg.replace("key-vim.host.PortGroup-", "")
+                    )
+
+            ret[h.name]["portgroups"] = {}
+            for portgroup in h.config.network.portgroup:
+                ret[h.name]["portgroups"][portgroup.spec.name] = {}
+                ret[h.name]["portgroups"][portgroup.spec.name]["vlan_id"] = portgroup.spec.vlanId,
+                ret[h.name]["portgroups"][portgroup.spec.name]["switch_name"] = portgroup.spec.vswitchName
 
             ret[h.name]["cpu_model"] = h.summary.hardware.cpuModel
             ret[h.name]["num_cpu_cores"] = h.summary.hardware.numCpuCores

--- a/src/saltext/vmware/modules/vm.py
+++ b/src/saltext/vmware/modules/vm.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+import json
 import logging
 
 import salt.exceptions
@@ -11,7 +12,7 @@ import saltext.vmware.utils.vm as utils_vm
 log = logging.getLogger(__name__)
 
 try:
-    from pyVmomi import vim
+    from pyVmomi import vim, VmomiSupport
 
     HAS_PYVMOMI = True
 except ImportError:
@@ -678,4 +679,4 @@ def get_mks_ticket(vm_name, ticket_type, service_instance=None, profile=None):
     vm_ref = utils_common.get_mor_by_property(service_instance, vim.VirtualMachine, vm_name)
     ticket = vm_ref.AcquireTicket(ticket_type)
 
-    return {"host": ticket.host, "ticket": ticket.ticket}
+    return json.loads(json.dumps(ticket, cls=VmomiSupport.VmomiJSONEncoder))

--- a/src/saltext/vmware/modules/vm.py
+++ b/src/saltext/vmware/modules/vm.py
@@ -649,34 +649,3 @@ def relocate(
     if ret == "success":
         return {"virtual_machine": "moved"}
     return {"virtual_machine": "failed to move"}
-
-def get_mks_ticket(vm_name, ticket_type, service_instance=None, profile=None):
-    """
-    Get ticket of virtual machine of passed object type.
-
-    vm_name
-        The name of the virtual machine to relocate.
-
-    ticket_type
-        Type of ticket.
-
-    service_instance
-        (optional) The Service Instance from which to obtain managed object references.
-
-    profile
-        Profile to use (optional)
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' vmware_vm.get_mks_ticket vm_name=vm01 ticket_type=webmks
-    """
-    if service_instance is None:
-        service_instance = connect.get_service_instance(config=__opts__, profile=profile)
-
-    log.info(f"Acquiring ticket {ticket_type} for {vm_name}")
-    vm_ref = utils_common.get_mor_by_property(service_instance, vim.VirtualMachine, vm_name)
-    ticket = vm_ref.AcquireTicket(ticket_type)
-
-    return json.loads(json.dumps(ticket, cls=VmomiSupport.VmomiJSONEncoder))

--- a/src/saltext/vmware/modules/vm.py
+++ b/src/saltext/vmware/modules/vm.py
@@ -648,3 +648,34 @@ def relocate(
     if ret == "success":
         return {"virtual_machine": "moved"}
     return {"virtual_machine": "failed to move"}
+
+def get_mks_ticket(vm_name, ticket_type, service_instance=None, profile=None):
+    """
+    Get ticket of virtual machine of passed object type.
+
+    vm_name
+        The name of the virtual machine to relocate.
+
+    ticket_type
+        Type of ticket.
+
+    service_instance
+        (optional) The Service Instance from which to obtain managed object references.
+
+    profile
+        Profile to use (optional)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' vmware_vm.get_mks_ticket vm_name=vm01 ticket_type=webmks
+    """
+    if service_instance is None:
+        service_instance = connect.get_service_instance(config=__opts__, profile=profile)
+
+    log.info(f"Acquiring ticket {ticket_type} for {vm_name}")
+    vm_ref = utils_common.get_mor_by_property(service_instance, vim.VirtualMachine, vm_name)
+    ticket = vm_ref.AcquireTicket(ticket_type)
+
+    return {"host": ticket.host, "ticket": ticket.ticket}

--- a/src/saltext/vmware/utils/vmware.py
+++ b/src/saltext/vmware/utils/vmware.py
@@ -573,6 +573,24 @@ def _get_dvs(service_instance, dvs_name):
 
     return None
 
+def _get_dvs_by_uuid(service_instance, dvs_uuid):
+    """
+    Return a reference to a Distributed Virtual Switch object.
+    :param service_instance: PyVmomi service instance
+    :param dvs_uuid: UUID of DVS to return
+    :return: A PyVmomi DVS object
+    """
+    switches = list_dvs(service_instance, ["uuid"])
+    if dvs_uuid in switches:
+        inventory = get_inventory(service_instance)
+        container = inventory.viewManager.CreateContainerView(
+            inventory.rootFolder, [vim.DistributedVirtualSwitch], True
+        )
+        for item in container.view:
+            if item.uuid == dvs_uuid:
+                return item
+
+    return None
 
 def _get_pnics(host_reference):
     """
@@ -2348,14 +2366,15 @@ def list_folders(service_instance):
     return utils_common.list_objects(service_instance, vim.Folder)
 
 
-def list_dvs(service_instance):
+def list_dvs(service_instance, properties=None):
     """
     Returns a list of distributed virtual switches associated with a given service instance.
-
     service_instance
         The Service Instance Object from which to obtain distributed virtual switches.
+    properties
+        An optional list of object properties used to return reference results.
     """
-    return utils_common.list_objects(service_instance, vim.DistributedVirtualSwitch)
+    return utils_common.list_objects(service_instance, vim.DistributedVirtualSwitch, properties)
 
 
 def list_vapps(service_instance):


### PR DESCRIPTION
The current implementation only returned basic nics information. However, in most cases this is not enough to run automation as we need to know how the VM is connected to the physical port of the host. If it uses DVS or standard switch, and what device the host is connected etc.

This PR solves such problems and provides a much detailed information about the following

- vnics
- pnics
- vswitches
- dvs
- portgroups
- cdp info