### PR TITLE
Adjust dependencies to allow installation on Salt OneDir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
           - 3.8
           - 3.9
         salt-version:
-          - 3004.1
+          - 3005.1
 
     steps:
     - uses: actions/checkout@v2
@@ -187,7 +187,7 @@ jobs:
         python-version:
           - 3.7
         salt-version:
-          - 3004.1
+          - 3005.1
 
     steps:
     - uses: actions/checkout@v2
@@ -310,7 +310,7 @@ jobs:
         python-version:
           - 3.7
         salt-version:
-          - 3004.1
+          - 3005.1
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -307,7 +307,7 @@ jobs:
       max-parallel: 3
       matrix:
         python-version:
-          - 3.7
+          - 3.9
         salt-version:
           - 3005.1
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ SKIP_REQUIREMENTS_INSTALL = "SKIP_REQUIREMENTS_INSTALL" in os.environ
 EXTRA_REQUIREMENTS_INSTALL = os.environ.get("EXTRA_REQUIREMENTS_INSTALL")
 
 COVERAGE_VERSION_REQUIREMENT = "coverage==5.2"
-SALT_REQUIREMENT = os.environ.get("SALT_REQUIREMENT") or "salt>=3003rc1"
+SALT_REQUIREMENT = os.environ.get("SALT_REQUIREMENT") or "salt>=3005"
 if SALT_REQUIREMENT == "salt==master":
     SALT_REQUIREMENT = "git+https://github.com/saltstack/salt.git@master"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     salt>=3002
     pyvmomi==7.0.3
     importlib_metadata; python_version < "3.8"
-    jinja2==3.1.0
+    jinja2<=3.1.0
 
 [options.extras_require]
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ setup_requires =
     setuptools>=50.3.2
     setuptools-declarative-requirements
 install_requires =
-    salt>=3002
+    salt>=3005
     pyvmomi==7.0.3
     importlib_metadata; python_version < "3.8"
     jinja2<=3.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,9 @@ setup_requires =
     setuptools-declarative-requirements
 install_requires =
     salt>=3002
-    pyvmomi==7.0.2
+    pyvmomi==7.0.3
     importlib_metadata; python_version < "3.8"
-    jinja2<=3.0.1
+    jinja2==3.1.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
This is a naive fix to adjust dependencies to match Salt OneDir 3005.1. I haven't been able to test this yet as I'm still trying to get `vsphere-automation-sdk-python` to install as well.

Also bumps pyVmomi to 7.0.3

Fixes #317 