### PR TITLE
Ignore changelog on end-of-file-fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: mixed-line-ending     # Replaces or checks mixed line ending.
         args: [--fix=lf]
       - id: end-of-file-fixer     # Makes sure files end in a newline and only a newline.
+        exclude: changelog/*
       - id: check-merge-conflict  # Check for files that contain merge conflict strings.
       - id: check-ast             # Simply check whether files parse as valid python.
 


### PR DESCRIPTION
We really honestly don't care, since towncrier will handle
stripping/adding newlines where necessary. It's totally fine for
changelog entries if they don't end with a single newline.
