### PR TITLE
Convert to use real .sls file for service instance

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,14 +28,14 @@ def salt_factories_config():
     }
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="session")
 def master(salt_factories):
     return salt_factories.salt_master_daemon(
         random_string("master-"), defaults={"enable_fqdns_grains": False}
     )
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="session")
 def minion(master):
     return master.salt_minion_daemon(
         random_string("minion-"), defaults={"enable_fqdns_grains": False}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,54 +28,54 @@ import saltext.vmware.states.vm as virtual_machine_state
 from saltext.vmware.utils.connect import get_service_instance
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="session")
 def master(master):
+    default_path = Path(__file__).parent.parent.parent / "local" / "vcenter.sls"
+    default_path = (
+        default_path
+        if default_path.exists()
+        else Path(__file__).parent.parent.parent / "local" / "vcenter.conf"
+    )
+    config_path = Path(os.environ.get("VCENTER_CONFIG", default_path))
+    pillar_path = master.pillar_tree.base.paths[0]
+    (pillar_path / "top.sls").write_text('base:\n  "*":\n    - vcenter')
+    (pillar_path / "vcenter.sls").write_bytes(config_path.read_bytes())
     with master.started():
         yield master
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="session")
 def minion(minion):
     with minion.started():
+        minion.salt_call_cli().run("saltutil.refresh_pillar")
         yield minion
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def salt_run_cli(master):
     return master.salt_run_cli()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def salt_cli(master):
     return master.get_salt_cli()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def salt_call_cli(minion):
     return minion.salt_call_cli()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def integration_test_config():
-    # Most of the values in the vcenter config are pulled using the vcenter
-    # credentials *in* the vcenter config, and are populated via a manual call
-    # to tools/test_value_scraper.py.
-    # This is not ideal.
-    default_path = Path(__file__).parent.parent.parent / "local" / "vcenter.conf"
-    config_path = Path(os.environ.get("VCENTER_CONFIG", default_path))
-
-    try:
-        with config_path.open() as f:
-            return json.load(f)
-    except Exception as e:  # pylint: disable=broad-except
-        return None
+    pytest.skip("TODO stop using integration test config")
 
 
 @pytest.fixture(scope="session")
-def service_instance(integration_test_config):
-    config = integration_test_config
+def service_instance(salt_call_cli):
+    config = salt_call_cli.run("pillar.items").json
     try:
-        si = get_service_instance(config={"saltext.vmware": config.copy()} if config else None)
+        si = get_service_instance(config=config if config else None)
         return si
     except Exception as e:  # pylint: disable=broad-except
         pytest.skip(f"Unable to create service instance from config. Error = {e}")


### PR DESCRIPTION
Part of work for #338 

As we do more for #338, we'll want to document creating `local/vcenter.sls` -- though honestly we could basically create a non-test-value-scraper helper script.

We're gonna need to refactor tests to stop using the `integration_test_config`, but... that should be a good thing :+1: 

As this is, it will skip all of those tests, but we're not running those on PRs anyway, so shouldn't be a big deal.