### PR TITLE
Move mock_with_name to tests.helpers

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,8 @@
+from unittest.mock import Mock
+
+
+def mock_with_name(name, *args, **kwargs):
+    # Can't mock name via constructor: https://docs.python.org/3/library/unittest.mock.html#mock-names-and-the-name-attribute
+    mock = Mock(*args, **kwargs)
+    mock.name = name
+    return mock

--- a/tests/unit/modules/test_dvportgroup.py
+++ b/tests/unit/modules/test_dvportgroup.py
@@ -5,17 +5,12 @@ from unittest.mock import patch
 import pytest
 import saltext.vmware.modules.dvportgroup as dvportgroup
 
+from tests.helpers import mock_with_name
+
 
 @pytest.fixture
 def configure_loader_modules():
     return {dvportgroup: {}}
-
-
-def mock_with_name(name, *args, **kwargs):
-    # Can't mock name via constructor: https://docs.python.org/3/library/unittest.mock.html#mock-names-and-the-name-attribute
-    mock = Mock(*args, **kwargs)
-    mock.name = name
-    return mock
 
 
 @pytest.fixture(

--- a/tests/unit/modules/test_storage_policies.py
+++ b/tests/unit/modules/test_storage_policies.py
@@ -6,12 +6,7 @@ import pytest
 import saltext.vmware.modules.storage_policies as storage_policies
 from pyVmomi import pbm
 
-
-def mock_with_name(name, *args, **kwargs):
-    # Can't mock name via constructor: https://docs.python.org/3/library/unittest.mock.html#mock-names-and-the-name-attribute
-    mock = Mock(*args, **kwargs)
-    mock.name = name
-    return mock
+from tests.helpers import mock_with_name
 
 
 def mock_pyvmomi_storage_policy_object(name):

--- a/tests/unit/states/test_firewall_rules.py
+++ b/tests/unit/states/test_firewall_rules.py
@@ -8,12 +8,7 @@ import saltext.vmware.modules.esxi as esxi_module
 import saltext.vmware.states.esxi as esxi
 from pyVmomi import vim
 
-
-def mock_with_name(name, *args, **kwargs):
-    # Can't mock name via constructor: https://docs.python.org/3/library/unittest.mock.html#mock-names-and-the-name-attribute
-    mock = Mock(*args, **kwargs)
-    mock.name = name
-    return mock
+from tests.helpers import mock_with_name
 
 
 sshClientMockObject = mock_with_name(

--- a/tests/unit/states/test_storage_policies.py
+++ b/tests/unit/states/test_storage_policies.py
@@ -7,12 +7,7 @@ import saltext.vmware.modules.storage_policies as storage_policies_module
 import saltext.vmware.states.storage_policies as storage_policies
 from pyVmomi import pbm
 
-
-def mock_with_name(name, *args, **kwargs):
-    # Can't mock name via constructor: https://docs.python.org/3/library/unittest.mock.html#mock-names-and-the-name-attribute
-    mock = Mock(*args, **kwargs)
-    mock.name = name
-    return mock
+from tests.helpers import mock_with_name
 
 
 def mock_pyvmomi_storage_policy_object(name):


### PR DESCRIPTION
This is a test infrastructure improvement.

We had ended up needing this not-actually-a-fixture all over the extension module. So... here we are creating it once and using it everywhere.

:rocket:
