### PR TITLE
Sri/ucm 146

### DIFF
--- a/src/saltext/vmware/modules/esxi.py
+++ b/src/saltext/vmware/modules/esxi.py
@@ -4,7 +4,6 @@ import logging
 import os
 from typing import List
 
-
 import salt.exceptions
 import saltext.vmware.utils.common as utils_common
 import saltext.vmware.utils.connect as utils_connect

--- a/src/saltext/vmware/modules/esxi.py
+++ b/src/saltext/vmware/modules/esxi.py
@@ -4,6 +4,7 @@ import logging
 import os
 from typing import List
 
+
 import salt.exceptions
 import saltext.vmware.utils.common as utils_common
 import saltext.vmware.utils.connect as utils_connect
@@ -4156,6 +4157,7 @@ def get_reference_schema():
     """
     log.debug("Running vmware_esxi.retrieve_reference_schema")
     return retrieve_reference_schema(Product.ESX)
+
 
 def pre_check(profile=None, cluster_paths=None, desired_state_spec=None, esx_config=None):
     """

--- a/src/saltext/vmware/modules/esxi.py
+++ b/src/saltext/vmware/modules/esxi.py
@@ -4156,3 +4156,58 @@ def get_reference_schema():
     """
     log.debug("Running vmware_esxi.retrieve_reference_schema")
     return retrieve_reference_schema(Product.ESX)
+
+def pre_check(profile=None, cluster_paths=None, desired_state_spec=None, esx_config=None):
+    """
+    Perform a pre-check for desired state compliance.
+    
+    :param profile: Profile name (optional)
+    :param cluster_paths: List of cluster paths (optional)
+    :param desired_state_spec: Desired state specification
+    :param esx_config: ESXi configuration (optional)
+    :return: Pre-check response
+    """
+    log.debug("Precheck %s", desired_state_spec)
+    
+    # Ensure esx_config is provided or create a new one
+    if not esx_config:
+        config = __opts__  
+        esx_config = utils_esxi.create_esx_config(config, profile)
+
+    log.debug("esx_config %s", esx_config)
+
+    try:
+        precheckresponse = esx_config.precheck_desired_state(desired_state_spec=desired_state_spec, cluster_paths=cluster_paths)        
+        return precheckresponse
+    
+    except Exception as e:        
+        log.error("Pre-check failed: %s", str(e))        
+        raise salt.exceptions.SaltException(str(e))
+        
+
+def remediate(profile=None, cluster_paths=None, desired_state_spec=None, esx_config=None):
+    """
+    Remediate the desired state compliance.
+    
+    :param profile: Profile name (optional)
+    :param cluster_paths: List of cluster paths (optional)
+    :param desired_state_spec: Desired state specification
+    :param esx_config: ESXi configuration (optional)
+    :return: Remediation response
+    """
+    log.debug("Remediate %s", desired_state_spec)
+
+    # Ensure esx_config is provided or create a new one
+    if not esx_config:
+        config = __opts__  
+        esx_config = utils_esxi.create_esx_config(config, profile)
+
+    log.debug("esx_config %s", esx_config)
+
+    try:
+        remediateresponse = esx_config.remediate_with_desired_state(desired_state_spec=desired_state_spec, cluster_paths=cluster_paths)        
+        return remediateresponse
+    
+    except Exception as e:
+        log.error("Remediation failed: %s", str(e))
+        raise salt.exceptions.SaltException(str(e))

--- a/src/saltext/vmware/modules/esxi.py
+++ b/src/saltext/vmware/modules/esxi.py
@@ -4162,7 +4162,7 @@ def get_reference_schema():
 def pre_check(profile=None, cluster_paths=None, desired_state_spec=None, esx_config=None):
     """
     Perform a pre-check for desired state compliance.
-    
+
     :param profile: Profile name (optional)
     :param cluster_paths: List of cluster paths (optional)
     :param desired_state_spec: Desired state specification
@@ -4170,27 +4170,29 @@ def pre_check(profile=None, cluster_paths=None, desired_state_spec=None, esx_con
     :return: Pre-check response
     """
     log.debug("Precheck %s", desired_state_spec)
-    
+
     # Ensure esx_config is provided or create a new one
     if not esx_config:
-        config = __opts__  
+        config = __opts__
         esx_config = utils_esxi.create_esx_config(config, profile)
 
     log.debug("esx_config %s", esx_config)
 
     try:
-        precheckresponse = esx_config.precheck_desired_state(desired_state_spec=desired_state_spec, cluster_paths=cluster_paths)        
+        precheckresponse = esx_config.precheck_desired_state(
+            desired_state_spec=desired_state_spec, cluster_paths=cluster_paths
+        )
         return precheckresponse
-    
-    except Exception as e:        
-        log.error("Pre-check failed: %s", str(e))        
+
+    except Exception as e:
+        log.error("Pre-check failed: %s", str(e))
         raise salt.exceptions.SaltException(str(e))
-        
+
 
 def remediate(profile=None, cluster_paths=None, desired_state_spec=None, esx_config=None):
     """
     Remediate the desired state compliance.
-    
+
     :param profile: Profile name (optional)
     :param cluster_paths: List of cluster paths (optional)
     :param desired_state_spec: Desired state specification
@@ -4201,15 +4203,17 @@ def remediate(profile=None, cluster_paths=None, desired_state_spec=None, esx_con
 
     # Ensure esx_config is provided or create a new one
     if not esx_config:
-        config = __opts__  
+        config = __opts__
         esx_config = utils_esxi.create_esx_config(config, profile)
 
     log.debug("esx_config %s", esx_config)
 
     try:
-        remediateresponse = esx_config.remediate_with_desired_state(desired_state_spec=desired_state_spec, cluster_paths=cluster_paths)        
+        remediateresponse = esx_config.remediate_with_desired_state(
+            desired_state_spec=desired_state_spec, cluster_paths=cluster_paths
+        )
         return remediateresponse
-    
+
     except Exception as e:
         log.error("Remediation failed: %s", str(e))
         raise salt.exceptions.SaltException(str(e))

--- a/tests/unit/modules/test_esxi.py
+++ b/tests/unit/modules/test_esxi.py
@@ -14,7 +14,6 @@ from config_modules_vmware.schema.schema_utility import Product
 from config_modules_vmware.schema.schema_utility import retrieve_reference_schema
 from salt.exceptions import SaltException
 
-
 log = logging.getLogger(__name__)
 
 

--- a/tests/unit/modules/test_esxi.py
+++ b/tests/unit/modules/test_esxi.py
@@ -13,6 +13,7 @@ import saltext.vmware.utils.connect
 from config_modules_vmware.schema.schema_utility import Product
 from config_modules_vmware.schema.schema_utility import retrieve_reference_schema
 from salt.exceptions import SaltException
+from saltext.vmware.utils.esxi import create_esx_config
 
 log = logging.getLogger(__name__)
 

--- a/tests/unit/modules/test_esxi.py
+++ b/tests/unit/modules/test_esxi.py
@@ -86,26 +86,31 @@ def fake_esx_config():
     }
     return fake
 
+
 @pytest.fixture
 def mock_esx_config(monkeypatch):
     # Define a mock for create_esx_config
     def mock_create_esx_config(config, profile):
         return mock_esx_config
 
-    monkeypatch.setattr(esxi, 'create_esx_config', mock_create_esx_config)
+    monkeypatch.setattr(esxi, "create_esx_config", mock_create_esx_config)
     return mock_esx_config
+
 
 @pytest.fixture
 def mock_desired_state_spec():
-    return {'example_key': 'example_value'}
+    return {"example_key": "example_value"}
+
 
 @pytest.fixture
 def mock_cluster_paths():
-    return ['example_path']
+    return ["example_path"]
+
 
 @pytest.fixture
 def mock_config():
-    return {'example_config_key': 'example_config_value'}
+    return {"example_config_key": "example_config_value"}
+
 
 def get_host(in_maintenance_mode=None):
     host = MagicMock()
@@ -377,48 +382,80 @@ def test_get_desired_configuration_all(fake_esx_config):
     configuration = esxi.get_desired_configuration(esx_config=fake_esx_config)
     assert configuration == {"path/to/cluster": {"config.module.submodule": "desired"}}
 
-def test_pre_check_success(mock_esx_config, mock_desired_state_spec, mock_cluster_paths, monkeypatch):
-    
+
+def test_pre_check_success(
+    mock_esx_config, mock_desired_state_spec, mock_cluster_paths, monkeypatch
+):
     # Define a mock for precheck_desired_state
     def mock_precheck_desired_state(desired_state_spec, cluster_paths):
-        return {'success_key': 'success_value'}
+        return {"success_key": "success_value"}
 
-    monkeypatch.setattr(mock_esx_config, 'precheck_desired_state', mock_precheck_desired_state)
+    monkeypatch.setattr(mock_esx_config, "precheck_desired_state", mock_precheck_desired_state)
 
-    result = esxi.pre_check(profile='example_profile', cluster_paths=mock_cluster_paths, desired_state_spec=mock_desired_state_spec, esx_config=mock_esx_config)
+    result = esxi.pre_check(
+        profile="example_profile",
+        cluster_paths=mock_cluster_paths,
+        desired_state_spec=mock_desired_state_spec,
+        esx_config=mock_esx_config,
+    )
 
-    assert result == {'success_key': 'success_value'}
+    assert result == {"success_key": "success_value"}
 
-def test_pre_check_exception(mock_esx_config, mock_desired_state_spec, mock_cluster_paths, monkeypatch):
-    
+
+def test_pre_check_exception(
+    mock_esx_config, mock_desired_state_spec, mock_cluster_paths, monkeypatch
+):
     # Define a mock for precheck_desired_state that raises an exception
     def mock_precheck_desired_state(desired_state_spec, cluster_paths):
-        raise Exception('Example Exception')
+        raise Exception("Example Exception")
 
-    monkeypatch.setattr(mock_esx_config, 'precheck_desired_state', mock_precheck_desired_state)
+    monkeypatch.setattr(mock_esx_config, "precheck_desired_state", mock_precheck_desired_state)
 
     with pytest.raises(SaltException):
-        esxi.pre_check(profile='example_profile', cluster_paths=mock_cluster_paths, desired_state_spec=mock_desired_state_spec, esx_config=mock_esx_config)
+        esxi.pre_check(
+            profile="example_profile",
+            cluster_paths=mock_cluster_paths,
+            desired_state_spec=mock_desired_state_spec,
+            esx_config=mock_esx_config,
+        )
 
-def test_remediate_success(mock_esx_config, mock_desired_state_spec, mock_cluster_paths, monkeypatch):
-    
+
+def test_remediate_success(
+    mock_esx_config, mock_desired_state_spec, mock_cluster_paths, monkeypatch
+):
     # Define a mock for remediate_with_desired_state
     def mock_remediate_with_desired_state(desired_state_spec, cluster_paths):
-        return {'success_key': 'success_value'}
+        return {"success_key": "success_value"}
 
-    monkeypatch.setattr(mock_esx_config, 'remediate_with_desired_state', mock_remediate_with_desired_state)
+    monkeypatch.setattr(
+        mock_esx_config, "remediate_with_desired_state", mock_remediate_with_desired_state
+    )
 
-    result = esxi.remediate(profile='example_profile', cluster_paths=mock_cluster_paths, desired_state_spec=mock_desired_state_spec, esx_config=mock_esx_config)
+    result = esxi.remediate(
+        profile="example_profile",
+        cluster_paths=mock_cluster_paths,
+        desired_state_spec=mock_desired_state_spec,
+        esx_config=mock_esx_config,
+    )
 
-    assert result == {'success_key': 'success_value'}
+    assert result == {"success_key": "success_value"}
 
-def test_remediate_exception(mock_esx_config, mock_desired_state_spec, mock_cluster_paths, monkeypatch):
-    
+
+def test_remediate_exception(
+    mock_esx_config, mock_desired_state_spec, mock_cluster_paths, monkeypatch
+):
     # Define a mock for remediate_with_desired_state that raises an exception
     def mock_remediate_with_desired_state(desired_state_spec, cluster_paths):
-        raise Exception('Example Exception')
+        raise Exception("Example Exception")
 
-    monkeypatch.setattr(mock_esx_config, 'remediate_with_desired_state', mock_remediate_with_desired_state)
+    monkeypatch.setattr(
+        mock_esx_config, "remediate_with_desired_state", mock_remediate_with_desired_state
+    )
 
     with pytest.raises(SaltException):
-        esxi.remediate(profile='example_profile', cluster_paths=mock_cluster_paths, desired_state_spec=mock_desired_state_spec, esx_config=mock_esx_config)
+        esxi.remediate(
+            profile="example_profile",
+            cluster_paths=mock_cluster_paths,
+            desired_state_spec=mock_desired_state_spec,
+            esx_config=mock_esx_config,
+        )


### PR DESCRIPTION
Creation of Execution Modules for Precheck and Remediate Execution modules for ESX.py 

Sample output response schema  for precheck module : 

 {
    "/SDDC-Datacenter/vlcm_cluster1": {
        "status": "OK",
        "summary": "Pre-check completed successfully.",
        "hosts": {
            "host-46": {
                "name": "esxi-6.vrack.vsphere.local",
                "summary": "Host is in compliance with desired configuration."
            },
            "host-51": {
                "name": "esxi-7.vrack.vsphere.local",
                "summary": "Host is in compliance with desired configuration."
            }
        },
        "successful_hosts": [
            "host-46",
            "host-51"
        ],
        "failed_hosts": [],
        "skipped_hosts": []
    }
}


-----------------------------

Sample output response schema for remediate 👍 

{
    "/SDDC-Datacenter/vlcm_cluster1": {
        "hosts": {
            "host-46": {
                "name": "esxi-6.vrack.vsphere.local"
            },
            "host-51": {
                "name": "esxi-7.vrack.vsphere.local"
            }
        },
        "successful_hosts": [
            "host-46",
            "host-51"
        ],
        "failed_hosts": [],
        "skipped_hosts": []
    }
}
