### PR TITLE
Add controller metadata module

### DIFF
--- a/docs/ref/modules/all.rst
+++ b/docs/ref/modules/all.rst
@@ -12,6 +12,7 @@ Execution Modules
     saltext.vmware.modules.cluster_drs
     saltext.vmware.modules.cluster_ha
     saltext.vmware.modules.compliance_control
+    saltext.vmware.modules.controller_metadata
     saltext.vmware.modules.datacenter
     saltext.vmware.modules.datastore
     saltext.vmware.modules.dvportgroup

--- a/docs/ref/modules/saltext.vmware.modules.controller_metadata.rst
+++ b/docs/ref/modules/saltext.vmware.modules.controller_metadata.rst
@@ -1,0 +1,6 @@
+
+saltext.vmware.modules.controller_metadata
+==========================================
+
+.. automodule:: saltext.vmware.modules.controller_metadata
+    :members:

--- a/docs/ref/states/all.rst
+++ b/docs/ref/states/all.rst
@@ -9,6 +9,7 @@ State Modules
     :toctree:
 
     saltext.vmware.states.compliance_control
+    saltext.vmware.states.controller_metadata
     saltext.vmware.states.datacenter
     saltext.vmware.states.datastore
     saltext.vmware.states.esxi

--- a/docs/ref/states/saltext.vmware.states.controller_metadata.rst
+++ b/docs/ref/states/saltext.vmware.states.controller_metadata.rst
@@ -1,0 +1,6 @@
+
+saltext.vmware.states.controller_metadata
+=========================================
+
+.. automodule:: saltext.vmware.states.controller_metadata
+    :members:

--- a/src/saltext/vmware/modules/controller_metadata.py
+++ b/src/saltext/vmware/modules/controller_metadata.py
@@ -1,0 +1,30 @@
+# SPDX-License: Apache-2.0
+import logging
+
+import salt.exceptions
+from config_modules_vmware.interfaces.metadata_interface import ControllerMetadataInterface
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "vmware_controller_metadata"
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def validate(controller_metadata):
+    """
+    Validates that the controller custom metadata is valid - has correct product/controls, format, and types.
+
+    controller_metadata
+        controller metadata dict to validate
+    """
+
+    log.info("Validating controller metadata: %s", controller_metadata)
+
+    try:
+        ControllerMetadataInterface.validate_custom_metadata(controller_metadata)
+    except Exception as exc:
+        log.error("Error when validating controller metadata: %s", str(exc))
+        raise salt.exceptions.VMwareRuntimeError(str(exc))

--- a/src/saltext/vmware/states/compliance_control.py
+++ b/src/saltext/vmware/states/compliance_control.py
@@ -3,7 +3,9 @@ import json
 import logging
 
 import saltext.vmware.utils.compliance_control as compliance_control_util
-from config_modules_vmware.framework.models.output_models.compliance_response import ComplianceStatus
+from config_modules_vmware.framework.models.output_models.compliance_response import (
+    ComplianceStatus,
+)
 from config_modules_vmware.framework.models.output_models.remediate_response import RemediateStatus
 
 log = logging.getLogger(__name__)
@@ -44,13 +46,13 @@ def check_control(name, control_config, product, ids=None, profile=None):
     log.debug("Opts: %s", __opts__)
 
     try:
-        compliance_config = control_config.get('compliance_config')
+        compliance_config = control_config.get("compliance_config")
         if not isinstance(compliance_config, dict) or not compliance_config:
             raise Exception(f"Desired spec is empty or not in correct format")
         else:
-            product_control_config = control_config.get('compliance_config', {}).get(product)
+            product_control_config = control_config.get("compliance_config", {}).get(product)
             if product_control_config:
-                control_config = {'compliance_config': {product: product_control_config}}
+                control_config = {"compliance_config": {product: product_control_config}}
             else:
                 err_msg = f"Desired spec is empty for {product}"
                 log.error(err_msg)
@@ -59,7 +61,7 @@ def check_control(name, control_config, product, ids=None, profile=None):
                     "result": None,
                     "changes": {},
                     "comment": err_msg,
-            }
+                }
 
         if __opts__["test"]:
             # If in test mode, perform audit
@@ -72,8 +74,10 @@ def check_control(name, control_config, product, ids=None, profile=None):
                 auth_context=auth_context,
             )
 
-            if (check_control_compliance_response["status"] == ComplianceStatus.COMPLIANT
-                    or check_control_compliance_response["status"] == ComplianceStatus.SKIPPED):
+            if (
+                check_control_compliance_response["status"] == ComplianceStatus.COMPLIANT
+                or check_control_compliance_response["status"] == ComplianceStatus.SKIPPED
+            ):
                 ret = {
                     "name": name,
                     "result": True,

--- a/src/saltext/vmware/states/controller_metadata.py
+++ b/src/saltext/vmware/states/controller_metadata.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+import json
+import logging
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = "vmware_controller_metadata"
+__proxyenabled__ = ["vmware_controller_metadata"]
+
+
+def __virtual__():
+    return __virtualname__
+
+
+def managed(name, controller_metadata, **kwargs):
+    """
+    Validates that the controller custom metadata is valid - has correct product/controls, format, and types.
+    If valid, will then invoke the file.managed module to persist the controller custom metadata.
+
+    name
+        The location of the file to manage, as an absolute path.
+    controller_metadata
+        controller metadata dict to validate and persist
+    kwargs
+        Keyword arguments to pass to 'file.managed' state module
+    """
+
+    log.info("Starting controller_metadata.managed for %s", name)
+
+    __salt__[
+        "vmware_controller_metadata.validate"
+    ](
+        controller_metadata=controller_metadata,
+    )
+
+    log.info("Controller metadata successfully validated")
+
+    log.info("Calling file.managed for controller metadata")
+    return __states__['file.managed'](name, contents=json.dumps(controller_metadata), **kwargs)

--- a/src/saltext/vmware/states/controller_metadata.py
+++ b/src/saltext/vmware/states/controller_metadata.py
@@ -27,13 +27,11 @@ def managed(name, controller_metadata, **kwargs):
 
     log.info("Starting controller_metadata.managed for %s", name)
 
-    __salt__[
-        "vmware_controller_metadata.validate"
-    ](
+    __salt__["vmware_controller_metadata.validate"](
         controller_metadata=controller_metadata,
     )
 
     log.info("Controller metadata successfully validated")
 
     log.info("Calling file.managed for controller metadata")
-    return __states__['file.managed'](name, contents=json.dumps(controller_metadata), **kwargs)
+    return __states__["file.managed"](name, contents=json.dumps(controller_metadata), **kwargs)

--- a/src/saltext/vmware/utils/compliance_control.py
+++ b/src/saltext/vmware/utils/compliance_control.py
@@ -28,7 +28,7 @@ def _create_vcenter_context(conf, fqdn):
         username=conf["user"],
         password=conf["password"],
         ssl_thumbprint=conf.get("ssl_thumbprint", None),
-        verify_ssl=conf.get("verify_ssl", True)
+        verify_ssl=conf.get("verify_ssl", True),
     )
 
 
@@ -38,7 +38,7 @@ def _create_sddc_manager_context(conf, fqdn):
         username=conf["user"],
         password=conf["password"],
         ssl_thumbprint=conf.get("ssl_thumbprint", None),
-        verify_ssl=conf.get("verify_ssl", True)
+        verify_ssl=conf.get("verify_ssl", True),
     )
 
 
@@ -50,7 +50,7 @@ def _create_esxi_context(vcenter_conf, fqdn=None, ids=None):
         vc_ssl_thumbprint=vcenter_conf.get("ssl_thumbprint", None),
         vc_saml_token=vcenter_conf.get("saml_token", None),
         esxi_host_names=ids,
-        verify_ssl=vcenter_conf.get("verify_ssl", True)
+        verify_ssl=vcenter_conf.get("verify_ssl", True),
     )
 
 

--- a/tests/unit/modules/test_controller_metadata.py
+++ b/tests/unit/modules/test_controller_metadata.py
@@ -1,0 +1,71 @@
+"""
+    :codeauthor: VMware
+"""
+import logging
+from unittest.mock import patch
+
+import pytest
+import salt.exceptions
+import saltext.vmware.modules.controller_metadata as controller_metadata
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def tgz_file(session_temp_dir):
+    tgz = session_temp_dir / "vmware.tgz"
+    tgz.write_bytes(b"1")
+    yield tgz
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {controller_metadata: {"__opts__": {}, "__pillar__": {}}}
+
+
+@pytest.fixture(autouse=True)
+def patch_salt_loaded_objects():
+    # This needs to be the same as the module we're importing
+    with patch(
+        "saltext.vmware.modules.controller_metadata.__opts__",
+        {
+            "cachedir": ".",
+            "saltext.vmware": {"host": "test.vcenter.local", "user": "test", "password": "test"},
+        },
+        create=True,
+    ), patch.object(controller_metadata, "__pillar__", {}, create=True), patch.object(
+        controller_metadata, "__salt__", {}, create=True
+    ):
+        yield
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [False, True],
+)
+def test_validate(exception):
+    patch_validate_exception = patch(
+        "config_modules_vmware.interfaces.metadata_interface.ControllerMetadataInterface.validate_custom_metadata",
+        autospec=True,
+        side_effect=Exception("Testing"),
+    )
+    mock_controller_metadata = {
+        "vcenter": {
+            "backup_schedule_config": {
+                "metadata": {
+                    "global_key": "global_value",
+                    "configuration_id": "1112",
+                    "instance_metadata_1": True,
+                    "metadata_2": {
+                        "nested_key_1": "nested_key_1_value"
+                    }
+                }
+            }
+        }
+    }
+    if exception:
+        with patch_validate_exception:
+            with pytest.raises(salt.exceptions.VMwareRuntimeError):
+                controller_metadata.validate(mock_controller_metadata)
+    else:
+        controller_metadata.validate(mock_controller_metadata)

--- a/tests/unit/modules/test_controller_metadata.py
+++ b/tests/unit/modules/test_controller_metadata.py
@@ -56,9 +56,7 @@ def test_validate(exception):
                     "global_key": "global_value",
                     "configuration_id": "1112",
                     "instance_metadata_1": True,
-                    "metadata_2": {
-                        "nested_key_1": "nested_key_1_value"
-                    }
+                    "metadata_2": {"nested_key_1": "nested_key_1_value"},
                 }
             }
         }

--- a/tests/unit/states/test_controller_metadata.py
+++ b/tests/unit/states/test_controller_metadata.py
@@ -1,0 +1,69 @@
+"""
+    Unit Tests for controller metadata
+"""
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from saltext.vmware.states import controller_metadata
+
+NAME = "test"
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {controller_metadata: {"__opts__": {}, "__pillar__": {}}}
+
+
+@pytest.fixture(autouse=True)
+def patch_salt_loaded_objects():
+    # This needs to be the same as the module we're importing
+    with patch(
+        "saltext.vmware.states.controller_metadata.__opts__",
+        {
+            "cachedir": ".",
+            "saltext.vmware": {"host": "test.vcenter.local", "user": "test", "password": "test"},
+        },
+        create=True,
+    ), patch.object(controller_metadata, "__pillar__", {}, create=True), patch.object(
+        controller_metadata, "__salt__", {}, create=True
+    ):
+        yield
+
+
+def test_managed():
+    mock_validate = MagicMock(return_value=True)
+    mock_file_managed = MagicMock(return_value={"Result": True})
+    mock_controller_metadata = {
+        "vcenter": {
+            "backup_schedule_config": {
+                "metadata": {
+                    "global_key": "global_value",
+                    "configuration_id": "1112",
+                    "instance_metadata_1": True,
+                    "metadata_2": {
+                        "nested_key_1": "nested_key_1_value"
+                    }
+                }
+            }
+        }
+    }
+
+    with patch.dict(
+        controller_metadata.__salt__,
+        {
+            "vmware_controller_metadata.validate": mock_validate,
+        },
+    ):
+        with patch.dict(
+                controller_metadata.__states__,
+                {
+                    "file.managed": mock_file_managed
+                },
+        ):
+            result = controller_metadata.managed(
+                name=NAME, controller_metadata=mock_controller_metadata
+            )
+
+    assert result is not None
+    assert result["Result"]

--- a/tests/unit/states/test_controller_metadata.py
+++ b/tests/unit/states/test_controller_metadata.py
@@ -41,9 +41,7 @@ def test_managed():
                     "global_key": "global_value",
                     "configuration_id": "1112",
                     "instance_metadata_1": True,
-                    "metadata_2": {
-                        "nested_key_1": "nested_key_1_value"
-                    }
+                    "metadata_2": {"nested_key_1": "nested_key_1_value"},
                 }
             }
         }
@@ -56,10 +54,8 @@ def test_managed():
         },
     ):
         with patch.dict(
-                controller_metadata.__states__,
-                {
-                    "file.managed": mock_file_managed
-                },
+            controller_metadata.__states__,
+            {"file.managed": mock_file_managed},
         ):
             result = controller_metadata.managed(
                 name=NAME, controller_metadata=mock_controller_metadata


### PR DESCRIPTION
Add new `controlller_metadata` module that will invoke the `validate_custom_metadata` method to validate that the custom metadata is valid - has correct product/controls, format, and types. If it is valid it will then invoke the `file.managed` state module to persist the custom metadata on the minions so that it can be used by config-modules

Example validation error
```
root@sddc-manager [ /home/vcf ]# salt -G 'product:vcenter' state.apply custom_metadata test=true
vcenter-1.vrack.vsphere.local:
----------
          ID: /tmp/config-module/controller_metadata.json
    Function: vmware_controller_metadata.managed
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/opt/saltstack/salt/extras-3.10/saltext/vmware/modules/controller_metadata.py", line 27, in validate
                  ControllerMetadataInterface.validate_custom_metadata(controller_metadata)
                File "/opt/saltstack/salt/extras-3.10/config_modules_vmware/interfaces/metadata_interface.py", line 91, in validate_custom_metadata
                  raise ValueError(
              ValueError: Metadata 'configuration_id' for product - vcenter, control - ntp should be of type '<class 'str'>'

              During handling of the above exception, another exception occurred:

              Traceback (most recent call last):
                File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/state.py", line 2423, in call
                  ret = self.states[cdata["full"]](
                File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 159, in __call__
                  ret = self.loader.run(run_func, *args, **kwargs)
                File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1245, in run
                  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
{% load_yaml as global %}
                File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1260, in _run_as
                  return _func_or_method(*args, **kwargs)
                File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1293, in wrapper
                  return f(*args, **kwargs)
                File "/opt/saltstack/salt/extras-3.10/saltext/vmware/states/controller_metadata.py", line 30, in managed
                  __salt__[
                File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 159, in __call__
                  ret = self.loader.run(run_func, *args, **kwargs)
                File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1245, in run
                  return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
                File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/loader/lazy.py", line 1260, in _run_as
                  return _func_or_method(*args, **kwargs)
                File "/opt/saltstack/salt/extras-3.10/saltext/vmware/modules/controller_metadata.py", line 30, in validate
                  raise salt.exceptions.VMwareRuntimeError(str(exc))
              salt.exceptions.VMwareRuntimeError: Metadata 'configuration_id' for product - vcenter, control - ntp should be of type '<class 'str'>'
     Started: 18:56:42.883871
    Duration: 10.577 ms
     Changes:

Summary for vcenter-1.vrack.vsphere.local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:  10.577 ms
ERROR: Minions returned with non-zero exit code
```

Example check compliance
```
root@sddc-manager [ /home/vcf ]# salt -G 'product:vcenter' state.apply custom_metadata test=true
vcenter-1.vrack.vsphere.local:
----------
          ID: /tmp/config-module/controller_metadata.json
    Function: vmware_controller_metadata.managed
      Result: None
     Comment: The file /tmp/config-module/controller_metadata.json is set to be changed
              Note: No changes made, actual changes may
              be different due to other states.
     Started: 18:57:01.318367
    Duration: 23.963 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -1 +1 @@
                  -{"vcenter": {"backup_schedule_config": {"metadata": {"global_key": "global_value", "configuration_id": "1112", "region_key": "region_value", "deployment_key": "deployment_value", "instance_metadata_1": true, "metadata_2": {"nested_key_1": "nested_key_1_value"}}}}}
                  +{"vcenter": {"backup_schedule_config": {"metadata": {"global_key": "global_value", "configuration_id": "1112", "region_key": "region_value", "deployment_key": "deployment_value", "instance_metadata_1": true, "metadata_2": {"nested_key_1": "nested_key_1_value"}}}, "ntp": {"metadata": {"configuration_id": "123"}}}}

Summary for vcenter-1.vrack.vsphere.local
------------
Succeeded: 1 (unchanged=1, changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  23.963 ms
```

Example remediate
```
root@sddc-manager [ /home/vcf ]# salt -G 'product:vcenter' state.apply custom_metadata
{% load_yaml as global %}
vcenter-1.vrack.vsphere.local:
----------
          ID: /tmp/config-module/controller_metadata.json
    Function: vmware_controller_metadata.managed
      Result: True
     Comment: File /tmp/config-module/controller_metadata.json updated
     Started: 18:57:14.462049
    Duration: 27.281 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -1 +1 @@
                  -{"vcenter": {"backup_schedule_config": {"metadata": {"global_key": "global_value", "configuration_id": "1112", "region_key": "region_value", "deployment_key": "deployment_value", "instance_metadata_1": true, "metadata_2": {"nested_key_1": "nested_key_1_value"}}}}}
                  +{"vcenter": {"backup_schedule_config": {"metadata": {"global_key": "global_value", "configuration_id": "1112", "region_key": "region_value", "deployment_key": "deployment_value", "instance_metadata_1": true, "metadata_2": {"nested_key_1": "nested_key_1_value"}}}, "ntp": {"metadata": {"configuration_id": "123"}}}}

Summary for vcenter-1.vrack.vsphere.local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  27.281 ms
```